### PR TITLE
Add automated tests for core modules

### DIFF
--- a/tests/test_avl_tree.cpp
+++ b/tests/test_avl_tree.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <iostream>
+#include "avl_tree.h"
+
+int main() {
+    AVLTree tree;
+    tree.insert({"Ivanov", 100}, 1);
+    tree.insert({"Petrov", 200}, 2);
+    tree.insert({"Sidorov", 150}, 3);
+    tree.insert({"Petrov", 200}, 5); // duplicate key adds line
+
+    // search existing key
+    auto node = tree.search({"Petrov", 200});
+    assert(node && node->lineNumbers.size() == 2);
+
+    // check in-order traversal (ascending)
+    auto inorder = tree.inorderNodes();
+    assert(inorder.size() == 3);
+    assert(inorder[0]->key.fullName == "Ivanov");
+    assert(inorder[1]->key.fullName == "Petrov");
+    assert(inorder[2]->key.fullName == "Sidorov");
+
+    // check reverse in-order (descending)
+    auto rev = tree.reverseInorderNodes();
+    assert(rev[0]->key.fullName == "Sidorov");
+    assert(rev[2]->key.fullName == "Ivanov");
+
+    // remove specific line for a key
+    assert(tree.removeLine({"Petrov", 200}, 5));
+    node = tree.search({"Petrov", 200});
+    assert(node && node->lineNumbers.size() == 1 && node->lineNumbers[0] == 2);
+
+    // remove entire node
+    assert(tree.remove({"Petrov", 200}));
+    assert(tree.search({"Petrov", 200}) == nullptr);
+
+    // removing last line deletes node
+    assert(tree.removeLine({"Ivanov", 100}, 1));
+    assert(tree.search({"Ivanov", 100}) == nullptr);
+
+    auto remaining = tree.inorderNodes();
+    assert(remaining.size() == 1);
+    assert(remaining[0]->key.fullName == "Sidorov");
+
+    std::cout << "AVL tree tests passed\n";
+    return 0;
+}

--- a/tests/test_doubly_linked_array.cpp
+++ b/tests/test_doubly_linked_array.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+#include <sstream>
+#include <iostream>
+#include "doubly_linked_array.hpp"
+
+int main() {
+    DoublyLinkedArray<int> list;
+    int a = list.push_back(1);
+    int b = list.push_back(2);
+    int c = list.push_back(3);
+    assert(list.at(a)->value == 1);
+    assert(list.at(b)->prev == a);
+    assert(list.at(c)->prev == b);
+    assert(list.remove(b));
+    assert(list.at(b) == nullptr);
+    std::ostringstream oss;
+    list.print(oss);
+    assert(oss.str() == "1 <-> 3");
+    std::cout << "Doubly linked list tests passed\n";
+    return 0;
+}

--- a/tests/test_hashtable.cpp
+++ b/tests/test_hashtable.cpp
@@ -1,0 +1,46 @@
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include "hashtable.hpp"
+
+int main() {
+    HashTable ht(4);
+    Record a{"Ivanov I I", 1, "Street", 12345, 10};
+    Record b{"Petrov P P", 2, "Ave", 67890, 20};
+    Record c{"Sidorov S S", 3, "Blvd", 11111, 30};
+    assert(ht.insert(a));
+    assert(ht.insert(b));
+    assert(ht.insert(c));
+    size_t idx; int steps;
+    assert(ht.search(b.fio, b.applicationNumber, idx, steps));
+    assert(ht.getOriginalLine(idx) == b.originalLine);
+    assert(ht.remove(b));
+    assert(!ht.search(b.fio, b.applicationNumber, idx, steps));
+    ht.clear();
+    assert(!ht.search(a.fio, a.applicationNumber, idx, steps));
+    ht.insert(a);
+    ht.saveToFile("ht_test.txt");
+    std::ifstream f("ht_test.txt");
+    std::string firstLine; std::getline(f, firstLine);
+    assert(firstLine.find("Idx") != std::string::npos);
+
+    // check automatic table expansion when load factor is exceeded
+    HashTable small(2); // start with minimal size to force growth
+    for (int i = 0; i < 10; ++i) {
+        Record r{"Name" + std::to_string(i), i, "St", 100 + i, i};
+        assert(small.insert(r));
+    }
+    // capture printed table to determine current capacity
+    std::ostringstream oss; small.print(oss);
+    std::string dump = oss.str();
+    size_t lines = std::count(dump.begin(), dump.end(), '\n');
+    // subtract header line to get number of buckets
+    size_t buckets = lines > 0 ? lines - 1 : 0;
+    assert(buckets > 2); // capacity must grow beyond initial size
+    // ensure one of the later records is still searchable after rehashing
+    assert(small.search("Name9", 9, idx, steps));
+    std::cout << "Module 2.3 tests passed\n";
+    return 0;
+}

--- a/tests/test_task2.cpp
+++ b/tests/test_task2.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include <vector>
+#include <iostream>
+#include "merge_sort.hpp"
+#include "modnaminecraft.hpp"
+
+static void test_sort_and_search() {
+    std::vector<Record> recs = {
+        {"Ivanov","I","I","Street1",111111,3,0},
+        {"Petrov","P","P","Street2",222222,1,1},
+        {"Sidorov","S","S","Street3",333333,2,2},
+        {"Fedorov","F","F","Street4",444444,1,3}
+    };
+    mergeSort(recs.data(), 0, static_cast<int>(recs.size()) - 1);
+    std::vector<int> keys;
+    for (const auto &r : recs) keys.push_back(r.applicationNumber);
+    assert((keys == std::vector<int>{1,1,2,3}));
+    auto bin = binarySearch(keys, 1);
+    assert(bin.first == 0);
+    assert(bin.second > 0);
+    auto lin = linearSearch(keys, 2);
+    assert((lin.first == std::vector<int>{2}));
+    assert(lin.second == static_cast<int>(keys.size()));
+}
+
+int main() {
+    test_sort_and_search();
+    std::cout << "Module 2.2 tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add C++ tests for merge sort and search routines in task 2.2
- introduce tests for hash table menu operations in task 2.3, including automatic resizing
- cover insert, traversal, removal and line deletion for the AVL tree

## Testing
- `g++ -std=c++17 -I . tests/test_task2.cpp merge_sort.cpp modnaminecraft.cpp -o tests/test_task2`
- `./tests/test_task2`
- `g++ -std=c++17 -I . tests/test_hashtable.cpp hashtable.cpp -o tests/test_hashtable`
- `./tests/test_hashtable`
- `g++ -std=c++17 -I . tests/test_doubly_linked_array.cpp -o tests/test_doubly`
- `./tests/test_doubly`
- `g++ -std=c++17 -I . tests/test_avl_tree.cpp avl_tree.cpp -o tests/test_avl_tree`
- `./tests/test_avl_tree`


------
https://chatgpt.com/codex/tasks/task_e_68a8269078888324be5aff65530d1641