### PR TITLE
Switch tests to Google Test framework

### DIFF
--- a/KursAch.vcxproj
+++ b/KursAch.vcxproj
@@ -135,6 +135,11 @@
     <ClCompile Include="KursAch.cpp" />
     <ClCompile Include="merge_sort.cpp" />
     <ClCompile Include="modnaminecraft.cpp" />
+    <ClCompile Include="tests\test_avl_tree.cpp" />
+    <ClCompile Include="tests\test_doubly_linked_array.cpp" />
+    <ClCompile Include="tests\test_hashtable.cpp" />
+    <ClCompile Include="tests\test_task2.cpp" />
+    <ClCompile Include="tests\test_main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="avl_tree.h" />

--- a/KursAch.vcxproj.filters
+++ b/KursAch.vcxproj.filters
@@ -36,6 +36,21 @@
     <ClCompile Include="avl_tree.cpp">
       <Filter>Исходные файлы</Filter>
     </ClCompile>
+    <ClCompile Include="tests\test_avl_tree.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\test_doubly_linked_array.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\test_hashtable.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\test_task2.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\test_main.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="hashtable.hpp">

--- a/tests/test_avl_tree.cpp
+++ b/tests/test_avl_tree.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include "../avl_tree.h"
+
+TEST(AVLTree, FullWorkflow) {
+    AVLTree tree;
+    tree.insert({"Ivanov", 100}, 1);
+    tree.insert({"Petrov", 200}, 2);
+    tree.insert({"Sidorov", 150}, 3);
+    tree.insert({"Petrov", 200}, 5); // duplicate key adds line
+
+    // search existing key
+    auto node = tree.search({"Petrov", 200});
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->lineNumbers.size(), 2);
+
+    // check in-order traversal (ascending)
+    auto inorder = tree.inorderNodes();
+    ASSERT_EQ(inorder.size(), 3);
+    EXPECT_EQ(inorder[0]->key.fullName, "Ivanov");
+    EXPECT_EQ(inorder[1]->key.fullName, "Petrov");
+    EXPECT_EQ(inorder[2]->key.fullName, "Sidorov");
+
+    // check reverse in-order (descending)
+    auto rev = tree.reverseInorderNodes();
+    EXPECT_EQ(rev[0]->key.fullName, "Sidorov");
+    EXPECT_EQ(rev[2]->key.fullName, "Ivanov");
+
+    // remove specific line for a key
+    EXPECT_TRUE(tree.removeLine({"Petrov", 200}, 5));
+    node = tree.search({"Petrov", 200});
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->lineNumbers.size(), 1);
+    EXPECT_EQ(node->lineNumbers[0], 2);
+
+    // remove entire node
+    EXPECT_TRUE(tree.remove({"Petrov", 200}));
+    EXPECT_EQ(tree.search({"Petrov", 200}), nullptr);
+
+    // removing last line deletes node
+    EXPECT_TRUE(tree.removeLine({"Ivanov", 100}, 1));
+    EXPECT_EQ(tree.search({"Ivanov", 100}), nullptr);
+
+    auto remaining = tree.inorderNodes();
+    ASSERT_EQ(remaining.size(), 1);
+    EXPECT_EQ(remaining[0]->key.fullName, "Sidorov");
+}
+

--- a/tests/test_doubly_linked_array.cpp
+++ b/tests/test_doubly_linked_array.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <sstream>
+#include "../doubly_linked_array.hpp"
+
+TEST(DoublyLinkedArray, BasicOperations) {
+    DoublyLinkedArray<int> list;
+    int a = list.push_back(1);
+    int b = list.push_back(2);
+    int c = list.push_back(3);
+
+    EXPECT_EQ(list.at(a)->value, 1);
+    EXPECT_EQ(list.at(b)->prev, a);
+    EXPECT_EQ(list.at(c)->prev, b);
+
+    EXPECT_TRUE(list.remove(b));
+    EXPECT_EQ(list.at(b), nullptr);
+
+    std::ostringstream oss;
+    list.print(oss);
+    EXPECT_EQ(oss.str(), "1 <-> 3");
+}
+

--- a/tests/test_hashtable.cpp
+++ b/tests/test_hashtable.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include "../hashtable.hpp"
+
+TEST(HashTable, BasicOperations) {
+    HashTable ht(4);
+    Record a{"Ivanov I I", 1, "Street", 12345, 10};
+    Record b{"Petrov P P", 2, "Ave", 67890, 20};
+    Record c{"Sidorov S S", 3, "Blvd", 11111, 30};
+
+    EXPECT_TRUE(ht.insert(a));
+    EXPECT_TRUE(ht.insert(b));
+    EXPECT_TRUE(ht.insert(c));
+
+    size_t idx; int steps;
+    EXPECT_TRUE(ht.search(b.fio, b.applicationNumber, idx, steps));
+    EXPECT_EQ(ht.getOriginalLine(idx), b.originalLine);
+
+    EXPECT_TRUE(ht.remove(b));
+    EXPECT_FALSE(ht.search(b.fio, b.applicationNumber, idx, steps));
+
+    ht.clear();
+    EXPECT_FALSE(ht.search(a.fio, a.applicationNumber, idx, steps));
+
+    ht.insert(a);
+    ht.saveToFile("ht_test.txt");
+    std::ifstream f("ht_test.txt");
+    std::string firstLine; std::getline(f, firstLine);
+    EXPECT_NE(firstLine.find("Idx"), std::string::npos);
+}
+
+TEST(HashTable, AutomaticExpansion) {
+    // start with minimal size to force growth
+    HashTable small(2);
+    for (int i = 0; i < 10; ++i) {
+        Record r{"Name" + std::to_string(i), i, "St", 100 + i, i};
+        EXPECT_TRUE(small.insert(r));
+    }
+
+    // capture printed table to determine current capacity
+    std::ostringstream oss; small.print(oss);
+    std::string dump = oss.str();
+    size_t lines = std::count(dump.begin(), dump.end(), '\n');
+    // subtract header line to get number of buckets
+    size_t buckets = lines > 0 ? lines - 1 : 0;
+    EXPECT_GT(buckets, 2);
+
+    size_t idx; int steps;
+    EXPECT_TRUE(small.search("Name9", 9, idx, steps));
+}
+

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_task2.cpp
+++ b/tests/test_task2.cpp
@@ -1,0 +1,29 @@
+// Google Test for merge sort and search routines from task 2.2
+#include <gtest/gtest.h>
+#include <vector>
+#include "../merge_sort.hpp"
+#include "../modnaminecraft.hpp"
+
+TEST(Task2, SortAndSearch) {
+    std::vector<Record> recs = {
+        {"Ivanov","I","I","Street1",111111,3,0},
+        {"Petrov","P","P","Street2",222222,1,1},
+        {"Sidorov","S","S","Street3",333333,2,2},
+        {"Fedorov","F","F","Street4",444444,1,3}
+    };
+
+    mergeSort(recs.data(), 0, static_cast<int>(recs.size()) - 1);
+
+    std::vector<int> keys;
+    for (const auto &r : recs) keys.push_back(r.applicationNumber);
+    EXPECT_EQ(keys, (std::vector<int>{1, 1, 2, 3}));
+
+    auto bin = binarySearch(keys, 1);
+    EXPECT_EQ(bin.first, 0);
+    EXPECT_GT(bin.second, 0);
+
+    auto lin = linearSearch(keys, 2);
+    EXPECT_EQ(lin.first, (std::vector<int>{2}));
+    EXPECT_EQ(lin.second, static_cast<int>(keys.size()));
+}
+


### PR DESCRIPTION
## Summary
- migrate all module tests to Google Test and centralize runner in `test_main.cpp`
- exercise merge sort and search, hash table operations with resizing, doubly linked array actions, and AVL tree workflow
- include test sources and runner in `KursAch.vcxproj` for IDE builds

## Testing
- `g++ -std=c++17 -I . tests/test_main.cpp tests/test_task2.cpp merge_sort.cpp modnaminecraft.cpp -lgtest -pthread -o tests/test_task2 && ./tests/test_task2`
- `g++ -std=c++17 -I . tests/test_main.cpp tests/test_hashtable.cpp hashtable.cpp -lgtest -pthread -o tests/test_hashtable && ./tests/test_hashtable`
- `g++ -std=c++17 -I . tests/test_main.cpp tests/test_doubly_linked_array.cpp -lgtest -pthread -o tests/test_doubly && ./tests/test_doubly`
- `g++ -std=c++17 -I . tests/test_main.cpp tests/test_avl_tree.cpp avl_tree.cpp -lgtest -pthread -o tests/test_avl_tree && ./tests/test_avl_tree`

------
https://chatgpt.com/codex/tasks/task_e_68a8269078888324be5aff65530d1641