### PR TITLE
Add integrator with linked-list storage

### DIFF
--- a/avl_tree.cpp
+++ b/avl_tree.cpp
@@ -1,12 +1,13 @@
 #include "avl_tree.h"
 #include <iostream>
 
-AVLTree::Node::Node(const PersonKey& k, int line)
-    : key(k), height(1), left(nullptr), right(nullptr) {
+AVLTree::Node::Node(int kIdx, int line)
+    : keyIndex(kIdx), height(1), left(nullptr), right(nullptr) {
     lineNumbers.push_back(line);
 }
 
-AVLTree::AVLTree() : root(nullptr) {}
+AVLTree::AVLTree(DoublyLinkedArray<PersonKey>& storage)
+    : root(nullptr), m_storage(storage) {}
 
 AVLTree::~AVLTree() { freeNode(root); }
 
@@ -19,6 +20,10 @@ void AVLTree::updateHeight(Node* n) {
 }
 
 int AVLTree::getBalance(Node* n) { return n ? height(n->left) - height(n->right) : 0; }
+
+const PersonKey& AVLTree::key(Node* n) const {
+    return m_storage.at(n->keyIndex)->value;
+}
 
 AVLTree::Node* AVLTree::rotateRight(Node* y) {
     Node* x = y->left;
@@ -70,13 +75,16 @@ AVLTree::Node* AVLTree::minNode(Node* node) {
     return node;
 }
 
-AVLTree::Node* AVLTree::insertNode(Node* node, const PersonKey& key, int lineNumber) {
-    if (!node) return new Node(key, lineNumber);
-    int cmp = keyCompare(key, node->key);
+AVLTree::Node* AVLTree::insertNode(Node* node, const PersonKey& keyVal, int lineNumber) {
+    if (!node) {
+        int idx = m_storage.push_back(keyVal);
+        return new Node(idx, lineNumber);
+    }
+    int cmp = keyCompare(keyVal, key(node));
     if (cmp < 0)
-        node->left = insertNode(node->left, key, lineNumber);
+        node->left = insertNode(node->left, keyVal, lineNumber);
     else if (cmp > 0)
-        node->right = insertNode(node->right, key, lineNumber);
+        node->right = insertNode(node->right, keyVal, lineNumber);
     else {
         node->lineNumbers.push_back(lineNumber);
         return node;
@@ -84,55 +92,62 @@ AVLTree::Node* AVLTree::insertNode(Node* node, const PersonKey& key, int lineNum
     return balanceNode(node);
 }
 
-void AVLTree::insert(const PersonKey& key, int lineNumber) {
-    root = insertNode(root, key, lineNumber);
+void AVLTree::insert(const PersonKey& keyVal, int lineNumber) {
+    root = insertNode(root, keyVal, lineNumber);
 }
 
-AVLTree::Node* AVLTree::removeNode(Node* node, const PersonKey& key, bool& removed) {
+AVLTree::Node* AVLTree::removeNode(Node* node, const PersonKey& keyVal, bool& removed) {
     if (!node) return nullptr;
-    int cmp = keyCompare(key, node->key);
+    int cmp = keyCompare(keyVal, key(node));
     if (cmp < 0) {
-        node->left = removeNode(node->left, key, removed);
+        node->left = removeNode(node->left, keyVal, removed);
     } else if (cmp > 0) {
-        node->right = removeNode(node->right, key, removed);
+        node->right = removeNode(node->right, keyVal, removed);
     } else {
         removed = true;
         if (!node->left || !node->right) {
             Node* temp = node->left ? node->left : node->right;
+            m_storage.remove(node->keyIndex);
             if (!temp) {
-                temp = node;
-                node = nullptr;
+                delete node;
+                return nullptr;
             } else {
                 *node = *temp;
+                delete temp;
             }
-            delete temp;
         } else {
             Node* temp = minNode(node->right);
-            node->key = temp->key;
+            PersonKey tempKey = key(temp);
             node->lineNumbers = temp->lineNumbers;
-            node->right = removeNode(node->right, temp->key, removed);
+            m_storage.at(node->keyIndex)->value = tempKey;
+            bool dummy = false;
+            node->right = removeNode(node->right, tempKey, dummy);
         }
     }
     if (!node) return node;
     return balanceNode(node);
 }
 
-bool AVLTree::remove(const PersonKey& key) {
+bool AVLTree::remove(const PersonKey& keyVal) {
     bool removed = false;
-    root = removeNode(root, key, removed);
+    root = removeNode(root, keyVal, removed);
     return removed;
 }
 
-AVLTree::Node* AVLTree::searchNode(Node* node, const PersonKey& key) const {
+AVLTree::Node* AVLTree::searchNode(Node* node, const PersonKey& keyVal) const {
     if (!node) return nullptr;
-    int cmp = keyCompare(key, node->key);
-    if (cmp < 0) return searchNode(node->left, key);
-    if (cmp > 0) return searchNode(node->right, key);
+    int cmp = keyCompare(keyVal, key(node));
+    if (cmp < 0) return searchNode(node->left, keyVal);
+    if (cmp > 0) return searchNode(node->right, keyVal);
     return node;
 }
 
-AVLTree::Node* AVLTree::search(const PersonKey& key) const {
-    return searchNode(root, key);
+AVLTree::Node* AVLTree::search(const PersonKey& keyVal) const {
+    return searchNode(root, keyVal);
+}
+
+const PersonKey& AVLTree::getKey(const Node* n) const {
+    return m_storage.at(n->keyIndex)->value;
 }
 
 void AVLTree::inorderTraversal(Node* node, std::vector<Node*>& result) const {
@@ -192,7 +207,8 @@ void AVLTree::printTreeRecursive(Node* node, std::vector<const char*>& stems, ch
     std::cout << "--";
     if (childType == 'L') std::cout << "(L) ";
     else if (childType == 'R') std::cout << "(R) ";
-    std::cout << node->key.fullName << " " << node->key.phoneNumber;
+    const PersonKey& k = key(node);
+    std::cout << k.fullName << " " << k.phoneNumber;
     if (!node->lineNumbers.empty()) {
         std::cout << " [";
         for (size_t i = 0; i < node->lineNumbers.size(); ++i) {

--- a/avl_tree.h
+++ b/avl_tree.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include "doubly_linked_array.hpp"
 
 // Key used in the AVL tree.  It consists of a person's full name and
 // phone number.  Two keys are compared lexicographically by name and then
@@ -28,21 +29,22 @@ class AVLTree {
 public:
     // Node of the tree.  Exposed so callers can inspect search results.
     struct Node {
-        PersonKey        key;        // composite key
+        int              keyIndex;   // index into external storage
         int              height;     // height of the subtree
         Node*            left;       // left child
         Node*            right;      // right child
         std::vector<int> lineNumbers;// lines in the input file
 
-        Node(const PersonKey& k, int line);
+        Node(int kIdx, int line);
     };
 
-    AVLTree();
+    AVLTree(DoublyLinkedArray<PersonKey>& storage);
     ~AVLTree();
 
     void insert(const PersonKey& key, int lineNumber);
     bool remove(const PersonKey& key);
     Node* search(const PersonKey& key) const;
+    const PersonKey& getKey(const Node* n) const;
 
     std::vector<Node*> inorderNodes() const;
     std::vector<Node*> reverseInorderNodes() const;
@@ -52,6 +54,7 @@ public:
 
 private:
     Node* root;
+    DoublyLinkedArray<PersonKey>& m_storage;
 
     static int  height(Node* n);
     static int  max(int a, int b);
@@ -62,6 +65,7 @@ private:
     static Node* minNode(Node* node);
 
     int   keyCompare(const PersonKey& a, const PersonKey& b) const;
+    const PersonKey& key(Node* n) const;
     Node* balanceNode(Node* node);
     Node* insertNode(Node* node, const PersonKey& key, int lineNumber);
     Node* removeNode(Node* node, const PersonKey& key, bool& removed);

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -1,0 +1,77 @@
+#ifndef DATA_INTEGRATOR_HPP
+#define DATA_INTEGRATOR_HPP
+
+#include "hashtable.hpp"
+#include "avl_tree.h"
+#include "doubly_linked_array.hpp"
+
+class DataIntegrator {
+public:
+    DataIntegrator(size_t hashSize = 4)
+        : hashStorage(),
+          treeStorage(),
+          hashtable(hashSize, hashStorage),
+          avlTree(treeStorage) {}
+
+    // Insert record into both structures.  Returns false on duplicate.
+    bool insertRecord(const Record& rec) {
+        if (!hashtable.insert(rec)) return false;
+        PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+        if (avlTree.search(pk)) {
+            hashtable.remove(rec);
+            return false;
+        }
+        avlTree.insert(pk, rec.originalLine);
+        return true;
+    }
+
+    // Remove record from hash table and corresponding entry from tree
+    bool removeByHash(const Record& rec) {
+        bool ok = hashtable.remove(rec);
+        if (ok) {
+            PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+            avlTree.remove(pk);
+        }
+        return ok;
+    }
+
+    // Insert only into hash table
+    bool insertHashOnly(const Record& rec) {
+        return hashtable.insert(rec);
+    }
+
+    // Remove only from hash table
+    bool removeHashOnly(const Record& rec) {
+        return hashtable.remove(rec);
+    }
+
+    // Insert into tree only if not present in hash table
+    bool insertTreeOnly(const PersonKey& pk, int line) {
+        size_t idx; int steps;
+        if (hashtable.search(pk.fullName, pk.phoneNumber, idx, steps)) {
+            return false; // conflicting key in hash table
+        }
+        if (avlTree.search(pk)) return false;
+        avlTree.insert(pk, line);
+        return true;
+    }
+
+    // Remove only from tree
+    bool removeTreeOnly(const PersonKey& pk) {
+        return avlTree.remove(pk);
+    }
+
+    // Retrieve record if present in both structures
+    bool getRecord(const std::string& fio, int applicationNumber, Record& out) const {
+        if (!hashtable.get(fio, applicationNumber, out)) return false;
+        PersonKey pk{out.fio, static_cast<int>(out.phoneNumber)};
+        return avlTree.search(pk) != nullptr;
+    }
+
+    DoublyLinkedArray<Record>     hashStorage;
+    DoublyLinkedArray<PersonKey>  treeStorage;
+    HashTable hashtable;
+    AVLTree   avlTree;
+};
+
+#endif // DATA_INTEGRATOR_HPP

--- a/hashtable.cpp
+++ b/hashtable.cpp
@@ -7,20 +7,18 @@
 // ---------------- HashTable::Cell ----------------
 
 HashTable::Cell::Cell()
-    : occupied(false),
-    data{ "", 0, "", 0LL, -1 }
-{}
+    : occupied(false), index(-1) {}
 
 // ---------------- HashTable ----------------
 
-HashTable::HashTable(size_t initialSize, double maxLoad)
+HashTable::HashTable(size_t initialSize, DoublyLinkedArray<Record>& storage, double maxLoad)
     : m_size(initialSize),
-    m_count(0),
-    m_initialSize(initialSize),
-    m_maxLoadFactor(maxLoad),
-    m_minLoadFactor(0.25),
-    table(new Cell[initialSize])
-{}
+      m_count(0),
+      m_initialSize(initialSize),
+      m_maxLoadFactor(maxLoad),
+      m_minLoadFactor(0.25),
+      table(new Cell[initialSize]),
+      m_storage(storage) {}
 
 HashTable::~HashTable() {
     delete[] table;
@@ -61,8 +59,20 @@ void HashTable::rehash(size_t newSize) {
     m_count = 0;
 
     for (size_t i = 0; i < oldSize; ++i) {
-        if (oldTable[i].occupied) {
-            insert(oldTable[i].data);
+        if (!oldTable[i].occupied) continue;
+        auto* node = m_storage.at(oldTable[i].index);
+        if (!node) continue;
+        const Record& rec = node->value;
+        std::string key = makeKey(rec.fio, rec.applicationNumber);
+        size_t base = hashPrimary(key);
+        for (size_t j = 0; j < m_size; ++j) {
+            size_t idx = hashSecondary(base, key, j);
+            if (!table[idx].occupied) {
+                table[idx].index = oldTable[i].index;
+                table[idx].occupied = true;
+                ++m_count;
+                break;
+            }
         }
     }
     delete[] oldTable;
@@ -75,7 +85,8 @@ bool HashTable::insert(const Record& rec) {
     for (size_t i = 0; i < m_size; ++i) {
         size_t idx = hashSecondary(base, key, i);
         if (!table[idx].occupied) {
-            table[idx].data = rec;
+            int index = m_storage.push_back(rec);
+            table[idx].index = index;
             table[idx].occupied = true;
             ++m_count;
             if ((double)m_count / m_size > m_maxLoadFactor) {
@@ -83,8 +94,9 @@ bool HashTable::insert(const Record& rec) {
             }
             return true;
         }
-        if (table[idx].data.fio == rec.fio &&
-            table[idx].data.applicationNumber == rec.applicationNumber)
+        auto* node = m_storage.at(table[idx].index);
+        if (node && node->value.fio == rec.fio &&
+            node->value.applicationNumber == rec.applicationNumber)
         {
             return false;
         }
@@ -102,8 +114,9 @@ bool HashTable::search(const std::string& fio, int applicationNumber,
         steps = int(i + 1);
         size_t idx = hashSecondary(base, key, i);
         if (!table[idx].occupied) return false;
-        if (table[idx].data.fio == fio &&
-            table[idx].data.applicationNumber == applicationNumber)
+        auto* node = m_storage.at(table[idx].index);
+        if (node && node->value.fio == fio &&
+            node->value.applicationNumber == applicationNumber)
         {
             out_index = idx;
             return true;
@@ -112,19 +125,32 @@ bool HashTable::search(const std::string& fio, int applicationNumber,
     return false;
 }
 
+bool HashTable::get(const std::string& fio, int applicationNumber, Record& out) const {
+    size_t idx; int steps = 0;
+    if (!search(fio, applicationNumber, idx, steps)) return false;
+    auto* node = m_storage.at(table[idx].index);
+    if (!node) return false;
+    out = node->value;
+    return true;
+}
+
 bool HashTable::remove(const Record& rec) {
     size_t idx; int steps = 0;
     if (!search(rec.fio, rec.applicationNumber, idx, steps))
         return false;
 
-    const Record& found = table[idx].data;
+    auto* node = m_storage.at(table[idx].index);
+    if (!node) return false;
+    const Record& found = node->value;
     if (found.street != rec.street ||
         found.phoneNumber != rec.phoneNumber)
     {
         return false;
     }
 
+    m_storage.remove(table[idx].index);
     table[idx].occupied = false;
+    table[idx].index = -1;
     --m_count;
     std::string key = makeKey(rec.fio, rec.applicationNumber);
     size_t      base = hashPrimary(key);
@@ -134,7 +160,8 @@ bool HashTable::remove(const Record& rec) {
         size_t curr = hashSecondary(base, key, i);
         if (!table[curr].occupied) break;
 
-        const Record& r2 = table[curr].data;
+        auto* node2 = m_storage.at(table[curr].index);
+        const Record& r2 = node2 ? node2->value : Record{"",0,"",0,0};
         size_t home = hashPrimary(makeKey(r2.fio, r2.applicationNumber));
 
         bool inRange;
@@ -144,9 +171,10 @@ bool HashTable::remove(const Record& rec) {
             inRange = (home <= prev || prev < curr);
 
         if (!inRange) {
-            table[prev].data = table[curr].data;
+            table[prev].index = table[curr].index;
             table[prev].occupied = true;
             table[curr].occupied = false;
+            table[curr].index = -1;
             prev = curr;
         }
     }
@@ -160,6 +188,11 @@ bool HashTable::remove(const Record& rec) {
 }
 
 void HashTable::clear() {
+    for (size_t i = 0; i < m_size; ++i) {
+        if (table[i].occupied) {
+            m_storage.remove(table[i].index);
+        }
+    }
     delete[] table;
     table = new Cell[m_size];
     m_count = 0;
@@ -171,7 +204,8 @@ void HashTable::print(std::ostream& out) const {
         out << i << "   | "
             << (table[i].occupied ? "OCCUPIED" : "FREE    ");
         if (table[i].occupied) {
-            const Record& r = table[i].data;
+            auto* node = m_storage.at(table[i].index);
+            const Record& r = node->value;
             out << " | "
                 << r.fio << ";"
                 << r.applicationNumber << ";"
@@ -189,7 +223,9 @@ void HashTable::saveToFile(const std::string& filename) const {
 }
 
 int HashTable::getOriginalLine(size_t index) const {
-    if (index < m_size && table[index].occupied)
-        return table[index].data.originalLine;
+    if (index < m_size && table[index].occupied) {
+        auto* node = m_storage.at(table[index].index);
+        if (node) return node->value.originalLine;
+    }
     return -1;
 }

--- a/hashtable.hpp
+++ b/hashtable.hpp
@@ -4,18 +4,22 @@
 #include <string>
 #include <ostream>
 #include "record3.hpp"
+#include "doubly_linked_array.hpp"
 
 // Closed addressing hash table implemented in an object-oriented manner.
 // Each bucket (Cell) stores a single record or is marked as free.
 class HashTable {
 public:
-    explicit HashTable(size_t initialSize, double maxLoad = 0.75);
+    explicit HashTable(size_t initialSize,
+                       DoublyLinkedArray<Record>& storage,
+                       double maxLoad = 0.75);
     ~HashTable();
 
     bool insert(const Record& rec);
     bool remove(const Record& rec);
     bool search(const std::string& fio, int applicationNumber,
         size_t& out_index, int& steps) const;
+    bool get(const std::string& fio, int applicationNumber, Record& out) const;
 
     void clear();
     void print(std::ostream& out) const;
@@ -24,14 +28,15 @@ public:
 
 private:
     struct Cell {
-        bool   occupied;
-        Record data;
+        bool occupied;
+        int  index;  // index into external storage
         Cell();
     };
 
     size_t m_size, m_count, m_initialSize;
     double m_maxLoadFactor, m_minLoadFactor;
     Cell* table;
+    DoublyLinkedArray<Record>& m_storage;
 
     std::string makeKey(const std::string& fio, int applicationNumber) const;
     size_t      hashPrimary(const std::string& key) const;

--- a/tests/test_avl_tree.cpp
+++ b/tests/test_avl_tree.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 #include "../avl_tree.h"
+#include "../doubly_linked_array.hpp"
 
 TEST(AVLTree, FullWorkflow) {
-    AVLTree tree;
+    DoublyLinkedArray<PersonKey> storage;
+    AVLTree tree(storage);
     tree.insert({"Ivanov", 100}, 1);
     tree.insert({"Petrov", 200}, 2);
     tree.insert({"Sidorov", 150}, 3);
@@ -16,14 +18,14 @@ TEST(AVLTree, FullWorkflow) {
     // check in-order traversal (ascending)
     auto inorder = tree.inorderNodes();
     ASSERT_EQ(inorder.size(), 3);
-    EXPECT_EQ(inorder[0]->key.fullName, "Ivanov");
-    EXPECT_EQ(inorder[1]->key.fullName, "Petrov");
-    EXPECT_EQ(inorder[2]->key.fullName, "Sidorov");
+    EXPECT_EQ(tree.getKey(inorder[0]).fullName, "Ivanov");
+    EXPECT_EQ(tree.getKey(inorder[1]).fullName, "Petrov");
+    EXPECT_EQ(tree.getKey(inorder[2]).fullName, "Sidorov");
 
     // check reverse in-order (descending)
     auto rev = tree.reverseInorderNodes();
-    EXPECT_EQ(rev[0]->key.fullName, "Sidorov");
-    EXPECT_EQ(rev[2]->key.fullName, "Ivanov");
+    EXPECT_EQ(tree.getKey(rev[0]).fullName, "Sidorov");
+    EXPECT_EQ(tree.getKey(rev[2]).fullName, "Ivanov");
 
     // remove specific line for a key
     EXPECT_TRUE(tree.removeLine({"Petrov", 200}, 5));
@@ -42,7 +44,7 @@ TEST(AVLTree, FullWorkflow) {
 
     auto remaining = tree.inorderNodes();
     ASSERT_EQ(remaining.size(), 1);
-    EXPECT_EQ(remaining[0]->key.fullName, "Sidorov");
+    EXPECT_EQ(tree.getKey(remaining[0]).fullName, "Sidorov");
 }
 
 

--- a/tests/test_hashtable.cpp
+++ b/tests/test_hashtable.cpp
@@ -4,9 +4,11 @@
 #include <fstream>
 #include <iostream>
 #include "../hashtable.hpp"
+#include "../doubly_linked_array.hpp"
 
 TEST(HashTable, BasicOperations) {
-    HashTable ht(4);
+    DoublyLinkedArray<Record> storage;
+    HashTable ht(4, storage);
     Record a{"Ivanov I I", 1, "Street", 12345, 10};
     Record b{"Petrov P P", 2, "Ave", 67890, 20};
     Record c{"Sidorov S S", 3, "Blvd", 11111, 30};
@@ -35,7 +37,8 @@ TEST(HashTable, BasicOperations) {
 
 TEST(HashTable, AutomaticExpansion) {
     // start with minimal size to force growth
-    HashTable small(2);
+    DoublyLinkedArray<Record> storage2;
+    HashTable small(2, storage2);
     for (int i = 0; i < 10; ++i) {
         Record r{"Name" + std::to_string(i), i, "St", 100 + i, i};
         EXPECT_TRUE(small.insert(r));

--- a/tests/test_integrator.cpp
+++ b/tests/test_integrator.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include "../data_integrator.hpp"
+
+TEST(Integrator, InsertAndRemove) {
+    DataIntegrator integrator;
+    Record rec{"Ivanov I I", 1, "Street", 12345, 1};
+    ASSERT_TRUE(integrator.insertRecord(rec));
+
+    size_t idx; int steps;
+    EXPECT_TRUE(integrator.hashtable.search(rec.fio, rec.applicationNumber, idx, steps));
+    PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+    EXPECT_NE(integrator.avlTree.search(pk), nullptr);
+
+    EXPECT_TRUE(integrator.removeByHash(rec));
+    EXPECT_EQ(integrator.avlTree.search(pk), nullptr);
+}
+
+TEST(Integrator, TreeInsertConflict) {
+    DataIntegrator integrator;
+    Record rec{"Ivanov I I", 1, "Street", 12345, 1};
+    ASSERT_TRUE(integrator.insertRecord(rec));
+
+    PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+    EXPECT_FALSE(integrator.insertTreeOnly(pk, 2));
+}
+
+TEST(Integrator, SeparateInsertAndAssemble) {
+    DataIntegrator integrator;
+    Record rec{"Petrov P P", 2, "Lane", 54321, 5};
+    ASSERT_TRUE(integrator.insertHashOnly(rec));
+    PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+    ASSERT_TRUE(integrator.insertTreeOnly(pk, rec.originalLine));
+
+    Record out;
+    EXPECT_TRUE(integrator.getRecord(rec.fio, rec.applicationNumber, out));
+    EXPECT_EQ(out.street, rec.street);
+}
+
+TEST(Integrator, SeparateRemovals) {
+    DataIntegrator integrator;
+    Record rec{"Sidorov S S", 3, "Ave", 11111, 7};
+    ASSERT_TRUE(integrator.insertRecord(rec));
+    PersonKey pk{rec.fio, static_cast<int>(rec.phoneNumber)};
+
+    EXPECT_TRUE(integrator.removeTreeOnly(pk));
+    size_t idx; int steps;
+    EXPECT_TRUE(integrator.hashtable.search(rec.fio, rec.applicationNumber, idx, steps));
+    Record out;
+    EXPECT_FALSE(integrator.getRecord(rec.fio, rec.applicationNumber, out));
+
+    EXPECT_TRUE(integrator.removeHashOnly(rec));
+    EXPECT_FALSE(integrator.hashtable.search(rec.fio, rec.applicationNumber, idx, steps));
+}


### PR DESCRIPTION
## Summary
- Store records for the hash table and AVL tree in shared doubly linked arrays
- Add `DataIntegrator` coordinating inserts and deletes across structures
- Extend tests for new storage model, integrator behaviors, and individual operations

## Testing
- `g++ -std=c++17 hashtable.cpp avl_tree.cpp tests/test_hashtable.cpp tests/test_avl_tree.cpp tests/test_doubly_linked_array.cpp tests/test_integrator.cpp tests/test_main.cpp -lgtest -lpthread -o tests/test_all`
- `tests/test_all`


------
https://chatgpt.com/codex/tasks/task_e_68c6973e6f7483248b242895a34ec0f2