### PR TITLE
Add integrator config file load/save tests

### DIFF
--- a/DoublyLinkedList.hpp
+++ b/DoublyLinkedList.hpp
@@ -21,6 +21,24 @@ public:
 
 template <typename U>
 constexpr bool is_stream_insertable_v = is_stream_insertable<U>::value;
+
+inline bool is_prime(int value) {
+    if (value <= 1) return false;
+    if (value == 2) return true;
+    if (value % 2 == 0) return false;
+    for (int i = 3; i * i <= value; i += 2) {
+        if (value % i == 0) return false;
+    }
+    return true;
+}
+
+inline int largest_prime_less_than(int value) {
+    if (value <= 2) return 2;
+    for (int candidate = value - 1; candidate >= 2; --candidate) {
+        if (is_prime(candidate)) return candidate;
+    }
+    return 2;
+}
 }
 
 // Doubly-linked list that supports storing arbitrary values while
@@ -177,7 +195,7 @@ public:
     std::enable_if_t<std::is_integral_v<U>, DoublyLinkedList<int>> map_to_prev_prime() const {
         DoublyLinkedList<int> out;
         for (Node* cur = head_; cur; cur = cur->next)
-            out.push_back(largest_prime_less_than(static_cast<int>(cur->data)));
+            out.push_back(detail::largest_prime_less_than(static_cast<int>(cur->data)));
         return out;
     }
 

--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1,9 +1,76 @@
 ﻿#include "data_integrator.hpp"
 
 #include <algorithm>
-#include <stdexcept>
-#include <vector>
 #include <cstdio>
+#include <fstream>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+
+void trimCarriageReturn(std::string& value) {
+    if (!value.empty() && value.back() == '\r') {
+        value.pop_back();
+    }
+}
+
+std::vector<std::string> splitLine(const std::string& line, char delimiter) {
+    std::vector<std::string> result;
+    std::string current;
+    for (char ch : line) {
+        if (ch == delimiter) {
+            result.push_back(current);
+            current.clear();
+        }
+        else {
+            current.push_back(ch);
+        }
+    }
+    result.push_back(current);
+    return result;
+}
+
+bool parseDriverLine(const std::string& line, DriverRecord& out) {
+    auto parts = splitLine(line, '|');
+    if (parts.size() != 4) return false;
+    for (auto& part : parts) trimCarriageReturn(part);
+
+    std::size_t consumed = 0;
+    int originalLine = 0;
+    try {
+        originalLine = std::stoi(parts[3], &consumed);
+    }
+    catch (...) {
+        return false;
+    }
+    if (consumed != parts[3].size()) return false;
+
+    if (parts[0].empty()) return false;
+
+    out.licenseNumber = std::move(parts[0]);
+    out.fio = std::move(parts[1]);
+    out.carBrand = std::move(parts[2]);
+    out.originalLine = originalLine;
+    return true;
+}
+
+bool parseOrderLine(const std::string& line, OrderRecord& out) {
+    auto parts = splitLine(line, '|');
+    if (parts.size() != 4) return false;
+    for (auto& part : parts) trimCarriageReturn(part);
+
+    if (parts[0].empty()) return false;
+
+    out.licenseNumber = std::move(parts[0]);
+    out.address = std::move(parts[1]);
+    out.cost = std::move(parts[2]);
+    out.date = std::move(parts[3]);
+    return true;
+}
+
+} // namespace
 
 DataIntegrator::DataIntegrator(std::size_t driverTableInitialSize, double maxLoadFactor)
     : drivers_(),
@@ -126,6 +193,85 @@ void DataIntegrator::clear() {
     driverTable_.clear();
     avl_free(&orderTree_);
     avl_init(&orderTree_);
+}
+
+bool DataIntegrator::loadFromFile(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) return false;
+
+    std::string header;
+    long long driverCountRaw = 0;
+    if (!(input >> header >> driverCountRaw)) return false;
+    if (header != "drivers" || driverCountRaw < 0) return false;
+    std::size_t driverCount = static_cast<std::size_t>(driverCountRaw);
+
+    std::string line;
+    std::getline(input, line); // consume the rest of the header line
+
+    std::vector<DriverRecord> parsedDrivers;
+    parsedDrivers.reserve(driverCount);
+    std::set<std::string> licenseNumbers;
+
+    for (std::size_t i = 0; i < driverCount; ++i) {
+        if (!std::getline(input, line)) return false;
+        DriverRecord record{};
+        if (!parseDriverLine(line, record)) return false;
+        if (!licenseNumbers.insert(record.licenseNumber).second) return false;
+        parsedDrivers.push_back(std::move(record));
+    }
+
+    long long orderCountRaw = 0;
+    if (!(input >> header >> orderCountRaw)) return false;
+    if (header != "orders" || orderCountRaw < 0) return false;
+    std::size_t orderCount = static_cast<std::size_t>(orderCountRaw);
+    std::getline(input, line);
+
+    std::vector<OrderRecord> parsedOrders;
+    parsedOrders.reserve(orderCount);
+
+    for (std::size_t i = 0; i < orderCount; ++i) {
+        if (!std::getline(input, line)) return false;
+        OrderRecord record{};
+        if (!parseOrderLine(line, record)) return false;
+        if (licenseNumbers.find(record.licenseNumber) == licenseNumbers.end()) return false;
+        parsedOrders.push_back(std::move(record));
+    }
+
+    clear();
+
+    for (const auto& driver : parsedDrivers) {
+        if (!addDriver(driver)) {
+            clear();
+            return false;
+        }
+    }
+
+    for (const auto& order : parsedOrders) {
+        if (!addOrder(order)) {
+            clear();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool DataIntegrator::saveToFile(const std::string& path) const {
+    std::ofstream output(path);
+    if (!output.is_open()) return false;
+
+    output << "drivers " << drivers_.size() << '\n';
+    drivers_.for_each([&](const DriverRecord& driver, std::size_t) {
+        output << driver.licenseNumber << '|' << driver.fio << '|' << driver.carBrand << '|' << driver.originalLine << '\n';
+    });
+
+    output << "orders " << orders_.size() << '\n';
+    orders_.for_each([&](const OrderRecord& order, std::size_t) {
+        output << order.licenseNumber << '|' << order.address << '|' << order.cost << '|' << order.date << '\n';
+    });
+
+    output.flush();
+    return static_cast<bool>(output);
 }
 
 std::optional<std::size_t> DataIntegrator::findDriverIndex(const std::string& licenseNumber) const {

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -31,6 +31,9 @@ public:
 
     void clear();
 
+    bool loadFromFile(const std::string& path);
+    bool saveToFile(const std::string& path) const;
+
 private:
     DoublyLinkedList<DriverRecord> drivers_;
     DoublyLinkedList<OrderRecord>  orders_;

--- a/tests/data/integrator/invalid_unknown_driver.cfg
+++ b/tests/data/integrator/invalid_unknown_driver.cfg
@@ -1,0 +1,4 @@
+drivers 1
+TK-400|Invalid Person|BMW|2
+orders 1
+TK-999|Unknown Address|0|2024-01-01

--- a/tests/data/integrator/valid_basic.cfg
+++ b/tests/data/integrator/valid_basic.cfg
@@ -1,0 +1,4 @@
+drivers 1
+TK-100|Ivanov Petr|Toyota|5
+orders 1
+TK-100|Lenina 1|2500|2024-12-01

--- a/tests/data/integrator/valid_multiple.cfg
+++ b/tests/data/integrator/valid_multiple.cfg
@@ -1,0 +1,7 @@
+drivers 2
+TK-200|Sidorov Ivan|Lada|8
+TK-201|Petrova Anna|Skoda|12
+orders 3
+TK-200|Nevsky 10|3500|2024-11-05
+TK-201|Mira 20|4500|2024-11-06
+TK-200|Sadovaya 33|1500|2024-11-07

--- a/tests/data/integrator/valid_no_orders.cfg
+++ b/tests/data/integrator/valid_no_orders.cfg
@@ -1,0 +1,4 @@
+drivers 2
+TK-300|Egorov Nikita|Hyundai|4
+TK-301|Semenova Olga|Kia|6
+orders 0

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -1,7 +1,38 @@
-﻿#include <gtest/gtest.h>
+﻿#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <system_error>
+#include <string>
+
 #include "data_integrator.hpp"
 
 namespace {
+
+std::filesystem::path ConfigPath(const std::string& name) {
+    static const std::filesystem::path base = std::filesystem::path(__FILE__).parent_path() / "data" / "integrator";
+    return base / name;
+}
+
+std::filesystem::path TempFilePathForCurrentTest() {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    std::filesystem::path tempDir = std::filesystem::temp_directory_path();
+    std::string fileName = "cursedarch_";
+    if (info && info->name()) {
+        fileName += info->name();
+    }
+    else {
+        fileName += "temp";
+    }
+    fileName += ".cfg";
+    return tempDir / fileName;
+}
+
+void RemoveIfExists(const std::filesystem::path& path) {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
 
 class IntegratorAddsDriverAndOrder : public ::testing::Test {
 protected:
@@ -29,6 +60,36 @@ protected:
 };
 
 class IntegratorUpdateDriverKeepsData : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorLoadsConfigBasic : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorLoadsConfigMultiple : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorLoadsConfigNoOrders : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorSavesToFile : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorSavesAndReloadsModifications : public ::testing::Test {
+protected:
+    void TestBody() override;
+};
+
+class IntegratorRejectsInvalidConfigFile : public ::testing::Test {
 protected:
     void TestBody() override;
 };
@@ -130,6 +191,166 @@ void IntegratorUpdateDriverKeepsData::TestBody() {
     EXPECT_EQ(stored->carBrand, "Tesla");
 }
 
+
+void IntegratorLoadsConfigBasic::TestBody() {
+    DataIntegrator integrator;
+    auto path = ConfigPath("valid_basic.cfg");
+    ASSERT_TRUE(integrator.loadFromFile(path.string()));
+
+    EXPECT_EQ(integrator.driverCount(), 1u);
+    EXPECT_EQ(integrator.orderCount(), 1u);
+
+    auto driver = integrator.findDriver("TK-100");
+    ASSERT_TRUE(driver.has_value());
+    EXPECT_EQ(driver->fio, "Ivanov Petr");
+    EXPECT_EQ(driver->carBrand, "Toyota");
+    EXPECT_EQ(driver->originalLine, 5);
+
+    auto orders = integrator.ordersForDriver("TK-100");
+    ASSERT_EQ(orders.size(), 1u);
+    EXPECT_EQ(orders[0].address, "Lenina 1");
+    EXPECT_EQ(orders[0].cost, "2500");
+    EXPECT_EQ(orders[0].date, "2024-12-01");
+}
+
+void IntegratorLoadsConfigMultiple::TestBody() {
+    DataIntegrator integrator;
+    ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_multiple.cfg").string()));
+
+    EXPECT_EQ(integrator.driverCount(), 2u);
+    EXPECT_EQ(integrator.orderCount(), 3u);
+
+    auto driver200 = integrator.findDriver("TK-200");
+    ASSERT_TRUE(driver200.has_value());
+    EXPECT_EQ(driver200->fio, "Sidorov Ivan");
+    EXPECT_EQ(driver200->carBrand, "Lada");
+
+    auto driver201 = integrator.findDriver("TK-201");
+    ASSERT_TRUE(driver201.has_value());
+    EXPECT_EQ(driver201->fio, "Petrova Anna");
+    EXPECT_EQ(driver201->carBrand, "Skoda");
+
+    auto orders200 = integrator.ordersForDriver("TK-200");
+    ASSERT_EQ(orders200.size(), 2u);
+    EXPECT_EQ(orders200[0].address, "Nevsky 10");
+    EXPECT_EQ(orders200[1].address, "Sadovaya 33");
+
+    auto orders201 = integrator.ordersForDriver("TK-201");
+    ASSERT_EQ(orders201.size(), 1u);
+    EXPECT_EQ(orders201[0].address, "Mira 20");
+}
+
+void IntegratorLoadsConfigNoOrders::TestBody() {
+    DataIntegrator integrator;
+    ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_no_orders.cfg").string()));
+
+    EXPECT_EQ(integrator.driverCount(), 2u);
+    EXPECT_EQ(integrator.orderCount(), 0u);
+
+    auto driver300 = integrator.findDriver("TK-300");
+    ASSERT_TRUE(driver300.has_value());
+    EXPECT_EQ(driver300->carBrand, "Hyundai");
+
+    auto driver301 = integrator.findDriver("TK-301");
+    ASSERT_TRUE(driver301.has_value());
+    EXPECT_EQ(driver301->fio, "Semenova Olga");
+
+    EXPECT_TRUE(integrator.ordersForDriver("TK-300").empty());
+    EXPECT_TRUE(integrator.ordersForDriver("TK-301").empty());
+}
+
+void IntegratorSavesToFile::TestBody() {
+    DataIntegrator integrator;
+    DriverRecord first{"DL-001", "Alpha Tester", "Tesla", 1};
+    DriverRecord second{"DL-002", "Beta Tester", "BMW", 2};
+    ASSERT_TRUE(integrator.addDriver(first));
+    ASSERT_TRUE(integrator.addDriver(second));
+
+    OrderRecord orderA{first.licenseNumber, "Street 7", "100", "2024-12-31"};
+    OrderRecord orderB{second.licenseNumber, "Street 8", "200", "2025-01-01"};
+    ASSERT_TRUE(integrator.addOrder(orderA));
+    ASSERT_TRUE(integrator.addOrder(orderB));
+
+    auto tempPath = TempFilePathForCurrentTest();
+    RemoveIfExists(tempPath);
+    ASSERT_TRUE(integrator.saveToFile(tempPath.string()));
+
+    std::ifstream input(tempPath);
+    ASSERT_TRUE(input.is_open());
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    input.close();
+
+    std::string expected =
+        "drivers 2\n"
+        "DL-001|Alpha Tester|Tesla|1\n"
+        "DL-002|Beta Tester|BMW|2\n"
+        "orders 2\n"
+        "DL-001|Street 7|100|2024-12-31\n"
+        "DL-002|Street 8|200|2025-01-01\n";
+    EXPECT_EQ(buffer.str(), expected);
+
+    RemoveIfExists(tempPath);
+}
+
+void IntegratorSavesAndReloadsModifications::TestBody() {
+    DataIntegrator integrator;
+    ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
+
+    auto driver = integrator.findDriver("TK-100");
+    ASSERT_TRUE(driver.has_value());
+    driver->carBrand = "UpdatedBrand";
+    driver->originalLine = 15;
+    EXPECT_TRUE(integrator.updateDriver(driver->licenseNumber, *driver));
+
+    auto existingOrders = integrator.ordersForDriver(driver->licenseNumber);
+    ASSERT_EQ(existingOrders.size(), 1u);
+    OrderRecord original = existingOrders[0];
+    OrderRecord updatedOrder = original;
+    updatedOrder.address = "Prospekt Mira 10";
+    updatedOrder.cost = "2700";
+    EXPECT_TRUE(integrator.updateOrder(original, updatedOrder));
+
+    OrderRecord newOrder{driver->licenseNumber, "Tverskaya 5", "3100", "2025-01-15"};
+    ASSERT_TRUE(integrator.addOrder(newOrder));
+    EXPECT_EQ(integrator.orderCount(), 2u);
+
+    auto tempPath = TempFilePathForCurrentTest();
+    RemoveIfExists(tempPath);
+    ASSERT_TRUE(integrator.saveToFile(tempPath.string()));
+
+    DataIntegrator reloaded;
+    ASSERT_TRUE(reloaded.loadFromFile(tempPath.string()));
+    auto reloadedDriver = reloaded.findDriver(driver->licenseNumber);
+    ASSERT_TRUE(reloadedDriver.has_value());
+    EXPECT_EQ(reloadedDriver->carBrand, "UpdatedBrand");
+    EXPECT_EQ(reloadedDriver->originalLine, 15);
+
+    auto reloadedOrders = reloaded.ordersForDriver(driver->licenseNumber);
+    ASSERT_EQ(reloadedOrders.size(), 2u);
+    EXPECT_NE(reloadedOrders.end(), std::find(reloadedOrders.begin(), reloadedOrders.end(), updatedOrder));
+    EXPECT_NE(reloadedOrders.end(), std::find(reloadedOrders.begin(), reloadedOrders.end(), newOrder));
+
+    RemoveIfExists(tempPath);
+}
+
+void IntegratorRejectsInvalidConfigFile::TestBody() {
+    DataIntegrator integrator;
+    DriverRecord existing{"SAFE-1", "Safe Driver", "VW", 3};
+    ASSERT_TRUE(integrator.addDriver(existing));
+    EXPECT_EQ(integrator.driverCount(), 1u);
+
+    auto invalidPath = ConfigPath("invalid_unknown_driver.cfg");
+    EXPECT_FALSE(integrator.loadFromFile(invalidPath.string()));
+
+    EXPECT_EQ(integrator.driverCount(), 1u);
+    EXPECT_EQ(integrator.orderCount(), 0u);
+    auto stored = integrator.findDriver(existing.licenseNumber);
+    ASSERT_TRUE(stored.has_value());
+    EXPECT_EQ(stored->fio, existing.fio);
+}
+
+
 } // namespace
 
 void RegisterIntegratorTests() {
@@ -145,4 +366,16 @@ void RegisterIntegratorTests() {
         []() -> ::testing::Test* { return new IntegratorUpdatesOrderKey; });
     ::testing::RegisterTest("DataIntegratorTest", "IntegratorUpdateDriverKeepsData", nullptr, nullptr, __FILE__, __LINE__,
         []() -> ::testing::Test* { return new IntegratorUpdateDriverKeepsData; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigBasic", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorLoadsConfigBasic; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigMultiple", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorLoadsConfigMultiple; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigNoOrders", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorLoadsConfigNoOrders; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorSavesToFile", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorSavesToFile; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorSavesAndReloadsModifications", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorSavesAndReloadsModifications; });
+    ::testing::RegisterTest("DataIntegratorTest", "IntegratorRejectsInvalidConfigFile", nullptr, nullptr, __FILE__, __LINE__,
+        []() -> ::testing::Test* { return new IntegratorRejectsInvalidConfigFile; });
 }


### PR DESCRIPTION
## Summary
- add parsing helpers plus load/save methods to the data integrator so it can read and persist configuration files
- create repository fixtures for valid and invalid integrator configs and extend the test suite with coverage for loading, saving, and modification scenarios
- supply the missing prime helper in the doubly linked list utility so the library continues to compile

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d00b1945288324bd37d2cae35b89b2