### PR TITLE
Use gtest macros for test registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /KursAch
 /build
 /out
+/.idea

--- a/KursAch.cpp
+++ b/KursAch.cpp
@@ -1,19 +1,7 @@
-#include <gtest/gtest.h>
+﻿#include <gtest/gtest.h>
 #include <cstdio>
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-
-    auto* unit = ::testing::UnitTest::GetInstance();
-    std::printf("total test suites: %d\n", unit->total_test_suite_count());
-    for (int i = 0; i < unit->total_test_suite_count(); ++i) {
-        const auto* suite = unit->GetTestSuite(i);
-        std::printf(" suite[%d]: %s has %d tests\n", i, suite->name(), suite->total_test_count());
-        for (int j = 0; j < suite->total_test_count(); ++j) {
-            const auto* info = suite->GetTestInfo(j);
-            std::printf("   test[%d]: %s\n", j, info->name());
-        }
-    }
-    std::printf("total tests before run: %d\n", unit->total_test_count());
     return RUN_ALL_TESTS();
 }

--- a/KursAch.cpp
+++ b/KursAch.cpp
@@ -1,17 +1,8 @@
-﻿#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 #include <cstdio>
-
-void RegisterDoublyLinkedListTests();
-void RegisterHashTableTests();
-void RegisterAVLTreeTests();
-void RegisterIntegratorTests();
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    RegisterDoublyLinkedListTests();
-    RegisterHashTableTests();
-    RegisterAVLTreeTests();
-    RegisterIntegratorTests();
 
     auto* unit = ::testing::UnitTest::GetInstance();
     std::printf("total test suites: %d\n", unit->total_test_suite_count());

--- a/tests/doubly_linked_list_test.cpp
+++ b/tests/doubly_linked_list_test.cpp
@@ -1,31 +1,8 @@
-﻿#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 #include "DoublyLinkedList.hpp"
 #include <sstream>
-#include <cstdio>
 
-namespace {
-
-class DoublyLinkedList_PushAndContains : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class DoublyLinkedList_RemoveReversePrint : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class DoublyLinkedList_RemoveBeforeValue : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class DoublyLinkedList_RemoveByIndexSwap : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-void DoublyLinkedList_PushAndContains::TestBody() {
+TEST(DoublyLinkedListTest, PushAndContains) {
     DoublyLinkedList<int> list;
     list.push_back(1);
     list.push_front(0);
@@ -36,7 +13,7 @@ void DoublyLinkedList_PushAndContains::TestBody() {
     EXPECT_TRUE(list.contains(2));
 }
 
-void DoublyLinkedList_RemoveReversePrint::TestBody() {
+TEST(DoublyLinkedListTest, RemoveReversePrint) {
     DoublyLinkedList<int> list;
     list.push_back(1);
     list.push_back(2);
@@ -53,7 +30,7 @@ void DoublyLinkedList_RemoveReversePrint::TestBody() {
     EXPECT_EQ(ss2.str(), "3 1 \n");
 }
 
-void DoublyLinkedList_RemoveBeforeValue::TestBody() {
+TEST(DoublyLinkedListTest, RemoveBeforeValue) {
     DoublyLinkedList<int> list;
     list.push_back(1);
     list.push_back(2);
@@ -64,7 +41,7 @@ void DoublyLinkedList_RemoveBeforeValue::TestBody() {
     EXPECT_EQ(ss.str(), "2 3 \n");
 }
 
-void DoublyLinkedList_RemoveByIndexSwap::TestBody() {
+TEST(DoublyLinkedListTest, RemoveByIndexSwap) {
     DoublyLinkedList<int> list;
     list.push_back(1);
     list.push_back(2);
@@ -76,18 +53,4 @@ void DoublyLinkedList_RemoveByIndexSwap::TestBody() {
     EXPECT_EQ(list.length(), 2);
     EXPECT_EQ(list.at(0), 3);
     EXPECT_EQ(list.at(1), 2);
-}
-
-} // namespace
-
-void RegisterDoublyLinkedListTests() {
-    std::printf("Registering DLL tests\n");
-    ::testing::RegisterTest("DoublyLinkedListTest", "PushAndContains", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new DoublyLinkedList_PushAndContains; });
-    ::testing::RegisterTest("DoublyLinkedListTest", "RemoveReversePrint", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new DoublyLinkedList_RemoveReversePrint; });
-    ::testing::RegisterTest("DoublyLinkedListTest", "RemoveBeforeValue", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new DoublyLinkedList_RemoveBeforeValue; });
-    ::testing::RegisterTest("DoublyLinkedListTest", "RemoveByIndexSwap", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new DoublyLinkedList_RemoveByIndexSwap; });
 }

--- a/tests/hashtable_test.cpp
+++ b/tests/hashtable_test.cpp
@@ -1,24 +1,13 @@
-﻿#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 #include "hashtable.hpp"
 
-namespace {
-
-class HashTableTest_InsertSearchRemove : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class HashTableTest_InsertDuplicateAndRehash : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-void HashTableTest_InsertSearchRemove::TestBody() {
+TEST(HashTableTest, InsertSearchRemove) {
     HashTable table(3);
     EXPECT_TRUE(table.insert("TK-25-111111-2023", 10));
     EXPECT_TRUE(table.insert("TK-25-222222-2024", 20));
 
-    std::size_t listIndex = 0; int steps = 0;
+    std::size_t listIndex = 0;
+    int steps = 0;
     EXPECT_TRUE(table.search("TK-25-111111-2023", listIndex, steps));
     EXPECT_EQ(listIndex, 10u);
 
@@ -33,7 +22,7 @@ void HashTableTest_InsertSearchRemove::TestBody() {
     EXPECT_FALSE(table.search("TK-25-222222-2024", listIndex, steps));
 }
 
-void HashTableTest_InsertDuplicateAndRehash::TestBody() {
+TEST(HashTableTest, InsertDuplicateAndRehash) {
     HashTable table(3);
     EXPECT_TRUE(table.insert("TK-25-111111-2023", 0));
     EXPECT_FALSE(table.insert("TK-25-111111-2023", 1));
@@ -43,16 +32,8 @@ void HashTableTest_InsertDuplicateAndRehash::TestBody() {
         table.insert(key, static_cast<std::size_t>(i));
     }
 
-    std::size_t listIndex = 0; int steps = 0;
+    std::size_t listIndex = 0;
+    int steps = 0;
     EXPECT_TRUE(table.search("TK-25-111111-2023", listIndex, steps));
     EXPECT_EQ(listIndex, 0u);
-}
-
-} // namespace
-
-void RegisterHashTableTests() {
-    ::testing::RegisterTest("HashTableTest", "InsertSearchRemove", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new HashTableTest_InsertSearchRemove; });
-    ::testing::RegisterTest("HashTableTest", "InsertDuplicateAndRehash", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new HashTableTest_InsertDuplicateAndRehash; });
 }

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -1,4 +1,4 @@
-﻿#include <algorithm>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -34,67 +34,9 @@ void RemoveIfExists(const std::filesystem::path& path) {
     std::filesystem::remove(path, ec);
 }
 
-class IntegratorAddsDriverAndOrder : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
+}  // namespace
 
-class IntegratorRejectsOrderWithoutDriver : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorCascadesDriverRemoval : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorMaintainsIndicesAfterOrderRemoval : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorUpdatesOrderKey : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorUpdateDriverKeepsData : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorLoadsConfigBasic : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorLoadsConfigMultiple : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorLoadsConfigNoOrders : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorSavesToFile : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorSavesAndReloadsModifications : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class IntegratorRejectsInvalidConfigFile : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-void IntegratorAddsDriverAndOrder::TestBody() {
+TEST(DataIntegratorTest, IntegratorAddsDriverAndOrder) {
     DataIntegrator integrator;
     DriverRecord driver{"TK-25-111111-2023", "Novikova Daria", "BMW", 10};
     OrderRecord order{driver.licenseNumber, "Ul. Lesnaya", "300 r.", "02 jan 2025"};
@@ -115,14 +57,14 @@ void IntegratorAddsDriverAndOrder::TestBody() {
     EXPECT_EQ(orders[0].address, order.address);
 }
 
-void IntegratorRejectsOrderWithoutDriver::TestBody() {
+TEST(DataIntegratorTest, IntegratorRejectsOrderWithoutDriver) {
     DataIntegrator integrator;
     OrderRecord order{"TK-25-333333-2025", "Ul. Mira", "500 r.", "05 feb 2025"};
     EXPECT_FALSE(integrator.addOrder(order));
     EXPECT_EQ(integrator.orderCount(), 0u);
 }
 
-void IntegratorCascadesDriverRemoval::TestBody() {
+TEST(DataIntegratorTest, IntegratorCascadesDriverRemoval) {
     DataIntegrator integrator;
     DriverRecord driver{"TK-25-444444-2025", "Melnikov Igor", "Audi", 5};
     OrderRecord o1{driver.licenseNumber, "Ul. Mira", "400 r.", "10 feb 2025"};
@@ -140,7 +82,7 @@ void IntegratorCascadesDriverRemoval::TestBody() {
     EXPECT_FALSE(integrator.hasOrder(o2));
 }
 
-void IntegratorMaintainsIndicesAfterOrderRemoval::TestBody() {
+TEST(DataIntegratorTest, IntegratorMaintainsIndicesAfterOrderRemoval) {
     DataIntegrator integrator;
     DriverRecord driver{"TK-25-555555-2025", "Sokolov Petr", "VW", 0};
     OrderRecord o1{driver.licenseNumber, "Street 1", "100 r.", "01 jan 2025"};
@@ -160,7 +102,7 @@ void IntegratorMaintainsIndicesAfterOrderRemoval::TestBody() {
     EXPECT_EQ(orders[1].address, o3.address);
 }
 
-void IntegratorUpdatesOrderKey::TestBody() {
+TEST(DataIntegratorTest, IntegratorUpdatesOrderKey) {
     DataIntegrator integrator;
     DriverRecord driver{"TK-25-666666-2025", "Alexeeva Olga", "Kia", 0};
     OrderRecord original{driver.licenseNumber, "Old Street", "150 r.", "01 mar 2025"};
@@ -178,7 +120,7 @@ void IntegratorUpdatesOrderKey::TestBody() {
     EXPECT_EQ(orders[0].cost, updated.cost);
 }
 
-void IntegratorUpdateDriverKeepsData::TestBody() {
+TEST(DataIntegratorTest, IntegratorUpdateDriverKeepsData) {
     DataIntegrator integrator;
     DriverRecord driver{"TK-25-777777-2025", "Smirnov Ilya", "Ford", 0};
     ASSERT_TRUE(integrator.addDriver(driver));
@@ -191,8 +133,7 @@ void IntegratorUpdateDriverKeepsData::TestBody() {
     EXPECT_EQ(stored->carBrand, "Tesla");
 }
 
-
-void IntegratorLoadsConfigBasic::TestBody() {
+TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
     DataIntegrator integrator;
     auto path = ConfigPath("valid_basic.cfg");
     ASSERT_TRUE(integrator.loadFromFile(path.string()));
@@ -213,7 +154,7 @@ void IntegratorLoadsConfigBasic::TestBody() {
     EXPECT_EQ(orders[0].date, "2024-12-01");
 }
 
-void IntegratorLoadsConfigMultiple::TestBody() {
+TEST(DataIntegratorTest, IntegratorLoadsConfigMultiple) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_multiple.cfg").string()));
 
@@ -240,7 +181,7 @@ void IntegratorLoadsConfigMultiple::TestBody() {
     EXPECT_EQ(orders201[0].address, "Mira 20");
 }
 
-void IntegratorLoadsConfigNoOrders::TestBody() {
+TEST(DataIntegratorTest, IntegratorLoadsConfigNoOrders) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_no_orders.cfg").string()));
 
@@ -259,7 +200,7 @@ void IntegratorLoadsConfigNoOrders::TestBody() {
     EXPECT_TRUE(integrator.ordersForDriver("TK-301").empty());
 }
 
-void IntegratorSavesToFile::TestBody() {
+TEST(DataIntegratorTest, IntegratorSavesToFile) {
     DataIntegrator integrator;
     DriverRecord first{"DL-001", "Alpha Tester", "Tesla", 1};
     DriverRecord second{"DL-002", "Beta Tester", "BMW", 2};
@@ -293,7 +234,7 @@ void IntegratorSavesToFile::TestBody() {
     RemoveIfExists(tempPath);
 }
 
-void IntegratorSavesAndReloadsModifications::TestBody() {
+TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
 
@@ -334,7 +275,7 @@ void IntegratorSavesAndReloadsModifications::TestBody() {
     RemoveIfExists(tempPath);
 }
 
-void IntegratorRejectsInvalidConfigFile::TestBody() {
+TEST(DataIntegratorTest, IntegratorRejectsInvalidConfigFile) {
     DataIntegrator integrator;
     DriverRecord existing{"SAFE-1", "Safe Driver", "VW", 3};
     ASSERT_TRUE(integrator.addDriver(existing));
@@ -348,34 +289,4 @@ void IntegratorRejectsInvalidConfigFile::TestBody() {
     auto stored = integrator.findDriver(existing.licenseNumber);
     ASSERT_TRUE(stored.has_value());
     EXPECT_EQ(stored->fio, existing.fio);
-}
-
-
-} // namespace
-
-void RegisterIntegratorTests() {
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorAddsDriverAndOrder", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorAddsDriverAndOrder; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorRejectsOrderWithoutDriver", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorRejectsOrderWithoutDriver; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorCascadesDriverRemoval", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorCascadesDriverRemoval; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorMaintainsIndicesAfterOrderRemoval", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorMaintainsIndicesAfterOrderRemoval; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorUpdatesOrderKey", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorUpdatesOrderKey; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorUpdateDriverKeepsData", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorUpdateDriverKeepsData; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigBasic", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorLoadsConfigBasic; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigMultiple", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorLoadsConfigMultiple; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorLoadsConfigNoOrders", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorLoadsConfigNoOrders; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorSavesToFile", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorSavesToFile; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorSavesAndReloadsModifications", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorSavesAndReloadsModifications; });
-    ::testing::RegisterTest("DataIntegratorTest", "IntegratorRejectsInvalidConfigFile", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new IntegratorRejectsInvalidConfigFile; });
 }

--- a/tests/tree_test.cpp
+++ b/tests/tree_test.cpp
@@ -1,30 +1,9 @@
-﻿#include <gtest/gtest.h>
+#include <gtest/gtest.h>
 #include "avl_tree.h"
 
-namespace {
-
-class AVLTreeTest_InsertAndSearch : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class AVLTreeTest_Remove : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class AVLTreeTest_RemoveIndex : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-class AVLTreeTest_InorderTraversal : public ::testing::Test {
-protected:
-    void TestBody() override;
-};
-
-void AVLTreeTest_InsertAndSearch::TestBody() {
-    AVLTree tree; avl_init(&tree);
+TEST(AVLTreeTest, InsertAndSearch) {
+    AVLTree tree;
+    avl_init(&tree);
     OrderRecord k{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
     avl_insert(&tree, k, 10);
     AVLNode* node = avl_search(&tree, k);
@@ -34,8 +13,9 @@ void AVLTreeTest_InsertAndSearch::TestBody() {
     avl_free(&tree);
 }
 
-void AVLTreeTest_Remove::TestBody() {
-    AVLTree tree; avl_init(&tree);
+TEST(AVLTreeTest, Remove) {
+    AVLTree tree;
+    avl_init(&tree);
     OrderRecord k1{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
     OrderRecord k2{"TK-25-222222-2024", "Ul. Lenina", "500 r.", "07 jan 2025"};
     avl_insert(&tree, k1, 1);
@@ -46,8 +26,9 @@ void AVLTreeTest_Remove::TestBody() {
     avl_free(&tree);
 }
 
-void AVLTreeTest_RemoveIndex::TestBody() {
-    AVLTree tree; avl_init(&tree);
+TEST(AVLTreeTest, RemoveIndex) {
+    AVLTree tree;
+    avl_init(&tree);
     OrderRecord k{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
     avl_insert(&tree, k, 1);
     avl_insert(&tree, k, 2);
@@ -61,8 +42,9 @@ void AVLTreeTest_RemoveIndex::TestBody() {
     avl_free(&tree);
 }
 
-void AVLTreeTest_InorderTraversal::TestBody() {
-    AVLTree tree; avl_init(&tree);
+TEST(AVLTreeTest, InorderTraversal) {
+    AVLTree tree;
+    avl_init(&tree);
     avl_insert(&tree, {"b", "2", "1 r.", "01 jan 2025"}, 0);
     avl_insert(&tree, {"a", "1", "1 r.", "01 jan 2025"}, 1);
     avl_insert(&tree, {"c", "3", "1 r.", "01 jan 2025"}, 2);
@@ -72,17 +54,4 @@ void AVLTreeTest_InorderTraversal::TestBody() {
     EXPECT_EQ(nodes[1]->key.licenseNumber, "b");
     EXPECT_EQ(nodes[2]->key.licenseNumber, "c");
     avl_free(&tree);
-}
-
-} // namespace
-
-void RegisterAVLTreeTests() {
-    ::testing::RegisterTest("AVLTreeTest", "InsertAndSearch", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new AVLTreeTest_InsertAndSearch; });
-    ::testing::RegisterTest("AVLTreeTest", "Remove", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new AVLTreeTest_Remove; });
-    ::testing::RegisterTest("AVLTreeTest", "RemoveIndex", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new AVLTreeTest_RemoveIndex; });
-    ::testing::RegisterTest("AVLTreeTest", "InorderTraversal", nullptr, nullptr, __FILE__, __LINE__,
-        []() -> ::testing::Test* { return new AVLTreeTest_InorderTraversal; });
 }


### PR DESCRIPTION
## Summary
- replace manual RegisterTest invocations with standard `TEST` macros in all test translation units
- simplify the custom test runner to rely on the automatic registration performed by GoogleTest

## Testing
- cmake --build build
- ctest

------
https://chatgpt.com/codex/tasks/task_e_68d0cf31e78c8324a2badedaca64bc4a