### PR TITLE
Add textual dumps and expand integrator data

### DIFF
--- a/avl_tree.cpp
+++ b/avl_tree.cpp
@@ -1,8 +1,10 @@
-﻿#include <string>
-#include <vector>
-#include <algorithm>
-#include "avl_tree.h"
+﻿#include <algorithm>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "avl_tree.h"
 
 static int height(AVLNode* n) {
     return n ? n->height : 0;
@@ -251,71 +253,80 @@ bool avl_replace_index(AVLTree* tree, const OrderRecord& key, std::size_t oldInd
     return false;
 }
 
-static const char* sdown = "  |";
-static const char* slast = "  `";
-static const char* snone = "   ";
+namespace {
 
-static void print_tree_recursive(AVLNode* node, std::vector<const char*>& stems, char childType) {
-    if (!node) return;
-
-    for (std::size_t i = 0; i < stems.size(); i++) {
-        std::cout << stems[i];
+void tree_to_stream(const AVLNode* node,
+                    std::ostream&     out,
+                    const std::string& prefix,
+                    bool                isTail,
+                    bool                isRoot) {
+    if (!node) {
+        return;
     }
 
-    std::cout << "--";
-    if (childType == 'L') {
-        std::cout << "(L) ";
-    }
-    else if (childType == 'R') {
-        std::cout << "(R) ";
+    out << prefix;
+    if (!isRoot) {
+        out << (isTail ? "`--" : "|--");
     }
 
-    std::cout << node->key.licenseNumber << " " << node->key.address;
+    out << node->key.licenseNumber << " | "
+        << node->key.address << " | "
+        << node->key.cost << " | "
+        << node->key.date;
+
     if (!node->listIndices.empty()) {
-        std::cout << " [";
-        for (std::size_t i = 0; i < node->listIndices.size(); i++) {
-            std::cout << node->listIndices[i];
-            if (i + 1 < node->listIndices.size()) std::cout << ",";
+        out << " [";
+        for (std::size_t i = 0; i < node->listIndices.size(); ++i) {
+            out << node->listIndices[i];
+            if (i + 1 < node->listIndices.size()) {
+                out << ",";
+            }
         }
-        std::cout << "]";
+        out << "]";
     }
-    std::cout << "\n";
+    out << '\n';
 
-    AVLNode* left = node->left;
-    AVLNode* right = node->right;
-
-    if (!left && !right) return;
-
-    std::size_t oldSize = stems.size();
-
-    if (left && right) {
-        stems.push_back(sdown);
-        print_tree_recursive(left, stems, 'L');
-        stems.pop_back();
-
-        stems.push_back(slast);
-        print_tree_recursive(right, stems, 'R');
-        stems.pop_back();
+    std::vector<const AVLNode*> children;
+    if (node->left) {
+        children.push_back(node->left);
     }
-    else if (left) {
-        stems.push_back(slast);
-        print_tree_recursive(left, stems, 'L');
-        stems.pop_back();
-    }
-    else {
-        stems.push_back(slast);
-        print_tree_recursive(right, stems, 'R');
-        stems.pop_back();
+    if (node->right) {
+        children.push_back(node->right);
     }
 
-    stems.resize(oldSize);
+    if (children.empty()) {
+        return;
+    }
+
+    std::string childPrefix;
+    if (!isRoot) {
+        childPrefix = prefix + (isTail ? "    " : "|   ");
+    }
+
+    for (std::size_t i = 0; i < children.size(); ++i) {
+        bool childIsTail = (i + 1 == children.size());
+        if (isRoot) {
+            tree_to_stream(children[i], out, "", childIsTail, false);
+        }
+        else {
+            tree_to_stream(children[i], out, childPrefix, childIsTail, false);
+        }
+    }
+}
+
+} // namespace
+
+std::string avl_tree_to_string(const AVLTree* tree) {
+    std::ostringstream out;
+    if (!tree || !tree->root) {
+        out << "(empty tree)\n";
+        return out.str();
+    }
+
+    tree_to_stream(tree->root, out, "", true, true);
+    return out.str();
 }
 
 void avl_print_tree(const AVLTree* tree) {
-    if (!tree || !tree->root) {
-        std::cout << "(empty tree)\n";
-        return;
-    }
-    std::vector<const char*> stems;
-    print_tree_recursive(tree->root, stems, '\0');
+    std::cout << avl_tree_to_string(tree);
 }

--- a/avl_tree.h
+++ b/avl_tree.h
@@ -2,7 +2,9 @@
 #define AVL_TREE_H
 
 #include <cstddef>
+#include <string>
 #include <vector>
+
 #include "order_record.hpp"
 
 struct AVLNode {
@@ -36,5 +38,6 @@ bool avl_remove_index(AVLTree* tree, const OrderRecord& key, std::size_t listInd
 bool avl_replace_index(AVLTree* tree, const OrderRecord& key, std::size_t oldIndex, std::size_t newIndex);
 
 void avl_print_tree(const AVLTree* tree);
+std::string avl_tree_to_string(const AVLTree* tree);
 
 #endif

--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -274,6 +274,40 @@ bool DataIntegrator::saveToFile(const std::string& path) const {
     return static_cast<bool>(output);
 }
 
+std::string DataIntegrator::hashTableAsText() const {
+    return driverTable_.toString();
+}
+
+std::string DataIntegrator::orderTreeAsText() const {
+    return avl_tree_to_string(&orderTree_);
+}
+
+bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std::string& treePath) const {
+    if (!hashTablePath.empty()) {
+        std::ofstream hashOut(hashTablePath);
+        if (!hashOut.is_open()) {
+            return false;
+        }
+        hashOut << hashTableAsText();
+        if (!hashOut) {
+            return false;
+        }
+    }
+
+    if (!treePath.empty()) {
+        std::ofstream treeOut(treePath);
+        if (!treeOut.is_open()) {
+            return false;
+        }
+        treeOut << orderTreeAsText();
+        if (!treeOut) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 std::optional<std::size_t> DataIntegrator::findDriverIndex(const std::string& licenseNumber) const {
     std::size_t index = 0;
     int steps = 0;

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -33,6 +33,9 @@ public:
 
     bool loadFromFile(const std::string& path);
     bool saveToFile(const std::string& path) const;
+    std::string hashTableAsText() const;
+    std::string orderTreeAsText() const;
+    bool saveStructures(const std::string& hashTablePath, const std::string& treePath) const;
 
 private:
     DoublyLinkedList<DriverRecord> drivers_;

--- a/hashtable.cpp
+++ b/hashtable.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <sstream>
 #include <utility>
 
 Cell::Cell()
@@ -131,20 +132,32 @@ void HashTable::clear() {
 }
 
 void HashTable::print(std::ostream& out) const {
-    out << "Idx | Status   | Key | ListIndex\n";
-    for (std::size_t i = 0; i < m_size; ++i) {
-        out << i << "   | "
-            << (table[i].occupied ? "OCCUPIED" : "FREE    ");
-        if (table[i].occupied) {
-            out << " | " << table[i].key << " | " << table[i].index;
-        }
-        out << "\n";
-    }
+    out << toString();
 }
 
 void HashTable::saveToFile(const std::string& filename) const {
     std::ofstream ofs(filename);
-    print(ofs);
+    ofs << toString();
+}
+
+std::string HashTable::toString() const {
+    std::ostringstream out;
+    out << "HashTable dump\n";
+    out << "Capacity: " << m_size << "\n";
+    out << "Elements: " << m_count << "\n";
+    out << "------------------------------\n";
+    for (std::size_t i = 0; i < m_size; ++i) {
+        out << "[" << i << "] ";
+        if (table[i].occupied) {
+            out << "occupied | key=\"" << table[i].key
+                << "\" | index=" << table[i].index;
+        }
+        else {
+            out << "empty";
+        }
+        out << "\n";
+    }
+    return out.str();
 }
 
 std::size_t HashTable::hashPrimary(const std::string& key) const {

--- a/hashtable.hpp
+++ b/hashtable.hpp
@@ -31,6 +31,7 @@ public:
     void clear();
     void print(std::ostream& out) const;
     void saveToFile(const std::string& filename) const;
+    std::string toString() const;
 
     std::size_t capacity() const { return m_size; }
     std::size_t size() const { return m_count; }

--- a/tests/data/integrator/valid_basic.cfg
+++ b/tests/data/integrator/valid_basic.cfg
@@ -1,4 +1,102 @@
-drivers 1
-TK-100|Ivanov Petr|Toyota|5
-orders 1
-TK-100|Lenina 1|2500|2024-12-01
+drivers 50
+VB-100|Basic Driver 1|Brand 1|1
+VB-101|Basic Driver 2|Brand 2|2
+VB-102|Basic Driver 3|Brand 3|3
+VB-103|Basic Driver 4|Brand 4|4
+VB-104|Basic Driver 5|Brand 5|5
+VB-105|Basic Driver 6|Brand 1|6
+VB-106|Basic Driver 7|Brand 2|7
+VB-107|Basic Driver 8|Brand 3|8
+VB-108|Basic Driver 9|Brand 4|9
+VB-109|Basic Driver 10|Brand 5|10
+VB-110|Basic Driver 11|Brand 1|11
+VB-111|Basic Driver 12|Brand 2|12
+VB-112|Basic Driver 13|Brand 3|13
+VB-113|Basic Driver 14|Brand 4|14
+VB-114|Basic Driver 15|Brand 5|15
+VB-115|Basic Driver 16|Brand 1|16
+VB-116|Basic Driver 17|Brand 2|17
+VB-117|Basic Driver 18|Brand 3|18
+VB-118|Basic Driver 19|Brand 4|19
+VB-119|Basic Driver 20|Brand 5|20
+VB-120|Basic Driver 21|Brand 1|21
+VB-121|Basic Driver 22|Brand 2|22
+VB-122|Basic Driver 23|Brand 3|23
+VB-123|Basic Driver 24|Brand 4|24
+VB-124|Basic Driver 25|Brand 5|25
+VB-125|Basic Driver 26|Brand 1|26
+VB-126|Basic Driver 27|Brand 2|27
+VB-127|Basic Driver 28|Brand 3|28
+VB-128|Basic Driver 29|Brand 4|29
+VB-129|Basic Driver 30|Brand 5|30
+VB-130|Basic Driver 31|Brand 1|31
+VB-131|Basic Driver 32|Brand 2|32
+VB-132|Basic Driver 33|Brand 3|33
+VB-133|Basic Driver 34|Brand 4|34
+VB-134|Basic Driver 35|Brand 5|35
+VB-135|Basic Driver 36|Brand 1|36
+VB-136|Basic Driver 37|Brand 2|37
+VB-137|Basic Driver 38|Brand 3|38
+VB-138|Basic Driver 39|Brand 4|39
+VB-139|Basic Driver 40|Brand 5|40
+VB-140|Basic Driver 41|Brand 1|41
+VB-141|Basic Driver 42|Brand 2|42
+VB-142|Basic Driver 43|Brand 3|43
+VB-143|Basic Driver 44|Brand 4|44
+VB-144|Basic Driver 45|Brand 5|45
+VB-145|Basic Driver 46|Brand 1|46
+VB-146|Basic Driver 47|Brand 2|47
+VB-147|Basic Driver 48|Brand 3|48
+VB-148|Basic Driver 49|Brand 4|49
+VB-149|Basic Driver 50|Brand 5|50
+orders 50
+VB-100|Basic Street 1|1000|2024-12-01
+VB-101|Basic Street 2|1010|2024-12-02
+VB-102|Basic Street 3|1020|2024-12-03
+VB-103|Basic Street 4|1030|2024-12-04
+VB-104|Basic Street 5|1040|2024-12-05
+VB-105|Basic Street 6|1050|2024-12-06
+VB-106|Basic Street 7|1060|2024-12-07
+VB-107|Basic Street 8|1070|2024-12-08
+VB-108|Basic Street 9|1080|2024-12-09
+VB-109|Basic Street 10|1090|2024-12-10
+VB-110|Basic Street 11|1100|2024-12-11
+VB-111|Basic Street 12|1110|2024-12-12
+VB-112|Basic Street 13|1120|2024-12-13
+VB-113|Basic Street 14|1130|2024-12-14
+VB-114|Basic Street 15|1140|2024-12-15
+VB-115|Basic Street 16|1150|2024-12-16
+VB-116|Basic Street 17|1160|2024-12-17
+VB-117|Basic Street 18|1170|2024-12-18
+VB-118|Basic Street 19|1180|2024-12-19
+VB-119|Basic Street 20|1190|2024-12-20
+VB-120|Basic Street 21|1200|2024-12-21
+VB-121|Basic Street 22|1210|2024-12-22
+VB-122|Basic Street 23|1220|2024-12-23
+VB-123|Basic Street 24|1230|2024-12-24
+VB-124|Basic Street 25|1240|2024-12-25
+VB-125|Basic Street 26|1250|2024-12-26
+VB-126|Basic Street 27|1260|2024-12-27
+VB-127|Basic Street 28|1270|2024-12-28
+VB-128|Basic Street 29|1280|2024-12-29
+VB-129|Basic Street 30|1290|2024-12-30
+VB-130|Basic Street 31|1300|2024-12-31
+VB-131|Basic Street 32|1310|2024-12-32
+VB-132|Basic Street 33|1320|2024-12-33
+VB-133|Basic Street 34|1330|2024-12-34
+VB-134|Basic Street 35|1340|2024-12-35
+VB-135|Basic Street 36|1350|2024-12-36
+VB-136|Basic Street 37|1360|2024-12-37
+VB-137|Basic Street 38|1370|2024-12-38
+VB-138|Basic Street 39|1380|2024-12-39
+VB-139|Basic Street 40|1390|2024-12-40
+VB-140|Basic Street 41|1400|2024-12-41
+VB-141|Basic Street 42|1410|2024-12-42
+VB-142|Basic Street 43|1420|2024-12-43
+VB-143|Basic Street 44|1430|2024-12-44
+VB-144|Basic Street 45|1440|2024-12-45
+VB-145|Basic Street 46|1450|2024-12-46
+VB-146|Basic Street 47|1460|2024-12-47
+VB-147|Basic Street 48|1470|2024-12-48
+VB-148|Basic Street 49|1480|2024-12-49
+VB-149|Basic Street 50|1490|2024-12-50

--- a/tests/data/integrator/valid_multiple.cfg
+++ b/tests/data/integrator/valid_multiple.cfg
@@ -1,7 +1,102 @@
-drivers 2
-TK-200|Sidorov Ivan|Lada|8
-TK-201|Petrova Anna|Skoda|12
-orders 3
-TK-200|Nevsky 10|3500|2024-11-05
-TK-201|Mira 20|4500|2024-11-06
-TK-200|Sadovaya 33|1500|2024-11-07
+drivers 50
+VM-200|Multiple Driver 1|MultiBrand 1|2
+VM-201|Multiple Driver 2|MultiBrand 2|4
+VM-202|Multiple Driver 3|MultiBrand 3|6
+VM-203|Multiple Driver 4|MultiBrand 4|8
+VM-204|Multiple Driver 5|MultiBrand 5|10
+VM-205|Multiple Driver 6|MultiBrand 6|12
+VM-206|Multiple Driver 7|MultiBrand 1|14
+VM-207|Multiple Driver 8|MultiBrand 2|16
+VM-208|Multiple Driver 9|MultiBrand 3|18
+VM-209|Multiple Driver 10|MultiBrand 4|20
+VM-210|Multiple Driver 11|MultiBrand 5|22
+VM-211|Multiple Driver 12|MultiBrand 6|24
+VM-212|Multiple Driver 13|MultiBrand 1|26
+VM-213|Multiple Driver 14|MultiBrand 2|28
+VM-214|Multiple Driver 15|MultiBrand 3|30
+VM-215|Multiple Driver 16|MultiBrand 4|32
+VM-216|Multiple Driver 17|MultiBrand 5|34
+VM-217|Multiple Driver 18|MultiBrand 6|36
+VM-218|Multiple Driver 19|MultiBrand 1|38
+VM-219|Multiple Driver 20|MultiBrand 2|40
+VM-220|Multiple Driver 21|MultiBrand 3|42
+VM-221|Multiple Driver 22|MultiBrand 4|44
+VM-222|Multiple Driver 23|MultiBrand 5|46
+VM-223|Multiple Driver 24|MultiBrand 6|48
+VM-224|Multiple Driver 25|MultiBrand 1|50
+VM-225|Multiple Driver 26|MultiBrand 2|52
+VM-226|Multiple Driver 27|MultiBrand 3|54
+VM-227|Multiple Driver 28|MultiBrand 4|56
+VM-228|Multiple Driver 29|MultiBrand 5|58
+VM-229|Multiple Driver 30|MultiBrand 6|60
+VM-230|Multiple Driver 31|MultiBrand 1|62
+VM-231|Multiple Driver 32|MultiBrand 2|64
+VM-232|Multiple Driver 33|MultiBrand 3|66
+VM-233|Multiple Driver 34|MultiBrand 4|68
+VM-234|Multiple Driver 35|MultiBrand 5|70
+VM-235|Multiple Driver 36|MultiBrand 6|72
+VM-236|Multiple Driver 37|MultiBrand 1|74
+VM-237|Multiple Driver 38|MultiBrand 2|76
+VM-238|Multiple Driver 39|MultiBrand 3|78
+VM-239|Multiple Driver 40|MultiBrand 4|80
+VM-240|Multiple Driver 41|MultiBrand 5|82
+VM-241|Multiple Driver 42|MultiBrand 6|84
+VM-242|Multiple Driver 43|MultiBrand 1|86
+VM-243|Multiple Driver 44|MultiBrand 2|88
+VM-244|Multiple Driver 45|MultiBrand 3|90
+VM-245|Multiple Driver 46|MultiBrand 4|92
+VM-246|Multiple Driver 47|MultiBrand 5|94
+VM-247|Multiple Driver 48|MultiBrand 6|96
+VM-248|Multiple Driver 49|MultiBrand 1|98
+VM-249|Multiple Driver 50|MultiBrand 2|100
+orders 50
+VM-200|Multiple Hub 1A|2307|2025-01-01
+VM-200|Multiple Hub 1B|2314|2025-01-02
+VM-200|Multiple Hub 1C|2321|2025-01-03
+VM-201|Multiple Hub 2A|2328|2025-01-04
+VM-201|Multiple Hub 2B|2335|2025-01-05
+VM-202|Multiple Route 3|2342|2025-01-06
+VM-203|Multiple Route 4|2349|2025-01-07
+VM-204|Multiple Route 5|2356|2025-01-08
+VM-205|Multiple Route 6|2363|2025-01-09
+VM-206|Multiple Route 7|2370|2025-01-10
+VM-207|Multiple Route 8|2377|2025-01-11
+VM-208|Multiple Route 9|2384|2025-01-12
+VM-209|Multiple Route 10|2391|2025-01-13
+VM-210|Multiple Route 11|2398|2025-01-14
+VM-211|Multiple Route 12|2405|2025-01-15
+VM-212|Multiple Route 13|2412|2025-01-16
+VM-213|Multiple Route 14|2419|2025-01-17
+VM-214|Multiple Route 15|2426|2025-01-18
+VM-215|Multiple Route 16|2433|2025-01-19
+VM-216|Multiple Route 17|2440|2025-01-20
+VM-217|Multiple Route 18|2447|2025-01-21
+VM-218|Multiple Route 19|2454|2025-01-22
+VM-219|Multiple Route 20|2461|2025-01-23
+VM-220|Multiple Route 21|2468|2025-01-24
+VM-221|Multiple Route 22|2475|2025-01-25
+VM-222|Multiple Route 23|2482|2025-01-26
+VM-223|Multiple Route 24|2489|2025-01-27
+VM-224|Multiple Route 25|2496|2025-01-28
+VM-225|Multiple Route 26|2503|2025-01-29
+VM-226|Multiple Route 27|2510|2025-01-30
+VM-227|Multiple Route 28|2517|2025-01-31
+VM-228|Multiple Route 29|2524|2025-01-32
+VM-229|Multiple Route 30|2531|2025-01-33
+VM-230|Multiple Route 31|2538|2025-01-34
+VM-231|Multiple Route 32|2545|2025-01-35
+VM-232|Multiple Route 33|2552|2025-01-36
+VM-233|Multiple Route 34|2559|2025-01-37
+VM-234|Multiple Route 35|2566|2025-01-38
+VM-235|Multiple Route 36|2573|2025-01-39
+VM-236|Multiple Route 37|2580|2025-01-40
+VM-237|Multiple Route 38|2587|2025-01-41
+VM-238|Multiple Route 39|2594|2025-01-42
+VM-239|Multiple Route 40|2601|2025-01-43
+VM-240|Multiple Route 41|2608|2025-01-44
+VM-241|Multiple Route 42|2615|2025-01-45
+VM-242|Multiple Route 43|2622|2025-01-46
+VM-243|Multiple Route 44|2629|2025-01-47
+VM-244|Multiple Route 45|2636|2025-01-48
+VM-245|Multiple Route 46|2643|2025-01-49
+VM-246|Multiple Route 47|2650|2025-01-50

--- a/tests/data/integrator/valid_no_orders.cfg
+++ b/tests/data/integrator/valid_no_orders.cfg
@@ -1,4 +1,52 @@
-drivers 2
-TK-300|Egorov Nikita|Hyundai|4
-TK-301|Semenova Olga|Kia|6
+drivers 50
+VN-300|NoOrder Driver 1|CalmBrand 1|3
+VN-301|NoOrder Driver 2|CalmBrand 2|6
+VN-302|NoOrder Driver 3|CalmBrand 3|9
+VN-303|NoOrder Driver 4|CalmBrand 4|12
+VN-304|NoOrder Driver 5|CalmBrand 1|15
+VN-305|NoOrder Driver 6|CalmBrand 2|18
+VN-306|NoOrder Driver 7|CalmBrand 3|21
+VN-307|NoOrder Driver 8|CalmBrand 4|24
+VN-308|NoOrder Driver 9|CalmBrand 1|27
+VN-309|NoOrder Driver 10|CalmBrand 2|30
+VN-310|NoOrder Driver 11|CalmBrand 3|33
+VN-311|NoOrder Driver 12|CalmBrand 4|36
+VN-312|NoOrder Driver 13|CalmBrand 1|39
+VN-313|NoOrder Driver 14|CalmBrand 2|42
+VN-314|NoOrder Driver 15|CalmBrand 3|45
+VN-315|NoOrder Driver 16|CalmBrand 4|48
+VN-316|NoOrder Driver 17|CalmBrand 1|51
+VN-317|NoOrder Driver 18|CalmBrand 2|54
+VN-318|NoOrder Driver 19|CalmBrand 3|57
+VN-319|NoOrder Driver 20|CalmBrand 4|60
+VN-320|NoOrder Driver 21|CalmBrand 1|63
+VN-321|NoOrder Driver 22|CalmBrand 2|66
+VN-322|NoOrder Driver 23|CalmBrand 3|69
+VN-323|NoOrder Driver 24|CalmBrand 4|72
+VN-324|NoOrder Driver 25|CalmBrand 1|75
+VN-325|NoOrder Driver 26|CalmBrand 2|78
+VN-326|NoOrder Driver 27|CalmBrand 3|81
+VN-327|NoOrder Driver 28|CalmBrand 4|84
+VN-328|NoOrder Driver 29|CalmBrand 1|87
+VN-329|NoOrder Driver 30|CalmBrand 2|90
+VN-330|NoOrder Driver 31|CalmBrand 3|93
+VN-331|NoOrder Driver 32|CalmBrand 4|96
+VN-332|NoOrder Driver 33|CalmBrand 1|99
+VN-333|NoOrder Driver 34|CalmBrand 2|102
+VN-334|NoOrder Driver 35|CalmBrand 3|105
+VN-335|NoOrder Driver 36|CalmBrand 4|108
+VN-336|NoOrder Driver 37|CalmBrand 1|111
+VN-337|NoOrder Driver 38|CalmBrand 2|114
+VN-338|NoOrder Driver 39|CalmBrand 3|117
+VN-339|NoOrder Driver 40|CalmBrand 4|120
+VN-340|NoOrder Driver 41|CalmBrand 1|123
+VN-341|NoOrder Driver 42|CalmBrand 2|126
+VN-342|NoOrder Driver 43|CalmBrand 3|129
+VN-343|NoOrder Driver 44|CalmBrand 4|132
+VN-344|NoOrder Driver 45|CalmBrand 1|135
+VN-345|NoOrder Driver 46|CalmBrand 2|138
+VN-346|NoOrder Driver 47|CalmBrand 3|141
+VN-347|NoOrder Driver 48|CalmBrand 4|144
+VN-348|NoOrder Driver 49|CalmBrand 1|147
+VN-349|NoOrder Driver 50|CalmBrand 2|150
 orders 0

--- a/tests/hashtable_test.cpp
+++ b/tests/hashtable_test.cpp
@@ -37,3 +37,15 @@ TEST(HashTableTest, InsertDuplicateAndRehash) {
     EXPECT_TRUE(table.search("TK-25-111111-2023", listIndex, steps));
     EXPECT_EQ(listIndex, 0u);
 }
+
+TEST(HashTableTest, DumpToStringContainsEntries) {
+    HashTable table(5);
+    ASSERT_TRUE(table.insert("HX-001", 10));
+    ASSERT_TRUE(table.insert("HX-002", 20));
+
+    std::string dump = table.toString();
+    EXPECT_NE(dump.find("HashTable dump"), std::string::npos);
+    EXPECT_NE(dump.find("HX-001"), std::string::npos);
+    EXPECT_NE(dump.find("HX-002"), std::string::npos);
+    EXPECT_NE(dump.find("[0]"), std::string::npos);
+}

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -138,66 +138,81 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
     auto path = ConfigPath("valid_basic.cfg");
     ASSERT_TRUE(integrator.loadFromFile(path.string()));
 
-    EXPECT_EQ(integrator.driverCount(), 1u);
-    EXPECT_EQ(integrator.orderCount(), 1u);
+    EXPECT_EQ(integrator.driverCount(), 50u);
+    EXPECT_EQ(integrator.orderCount(), 50u);
 
-    auto driver = integrator.findDriver("TK-100");
-    ASSERT_TRUE(driver.has_value());
-    EXPECT_EQ(driver->fio, "Ivanov Petr");
-    EXPECT_EQ(driver->carBrand, "Toyota");
-    EXPECT_EQ(driver->originalLine, 5);
+    auto firstDriver = integrator.findDriver("VB-100");
+    ASSERT_TRUE(firstDriver.has_value());
+    EXPECT_EQ(firstDriver->fio, "Basic Driver 1");
+    EXPECT_EQ(firstDriver->carBrand, "Brand 1");
+    EXPECT_EQ(firstDriver->originalLine, 1);
 
-    auto orders = integrator.ordersForDriver("TK-100");
-    ASSERT_EQ(orders.size(), 1u);
-    EXPECT_EQ(orders[0].address, "Lenina 1");
-    EXPECT_EQ(orders[0].cost, "2500");
-    EXPECT_EQ(orders[0].date, "2024-12-01");
+    auto firstOrders = integrator.ordersForDriver("VB-100");
+    ASSERT_EQ(firstOrders.size(), 1u);
+    EXPECT_EQ(firstOrders[0].address, "Basic Street 1");
+    EXPECT_EQ(firstOrders[0].cost, "1000");
+    EXPECT_EQ(firstOrders[0].date, "2024-12-01");
+
+    auto lastDriver = integrator.findDriver("VB-149");
+    ASSERT_TRUE(lastDriver.has_value());
+    EXPECT_EQ(lastDriver->fio, "Basic Driver 50");
+    EXPECT_EQ(lastDriver->carBrand, "Brand 5");
+
+    auto lastOrders = integrator.ordersForDriver("VB-149");
+    ASSERT_EQ(lastOrders.size(), 1u);
+    EXPECT_EQ(lastOrders[0].address, "Basic Street 50");
+    EXPECT_EQ(lastOrders[0].cost, "1490");
 }
 
 TEST(DataIntegratorTest, IntegratorLoadsConfigMultiple) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_multiple.cfg").string()));
 
-    EXPECT_EQ(integrator.driverCount(), 2u);
-    EXPECT_EQ(integrator.orderCount(), 3u);
+    EXPECT_EQ(integrator.driverCount(), 50u);
+    EXPECT_EQ(integrator.orderCount(), 50u);
 
-    auto driver200 = integrator.findDriver("TK-200");
+    auto driver200 = integrator.findDriver("VM-200");
     ASSERT_TRUE(driver200.has_value());
-    EXPECT_EQ(driver200->fio, "Sidorov Ivan");
-    EXPECT_EQ(driver200->carBrand, "Lada");
+    EXPECT_EQ(driver200->fio, "Multiple Driver 1");
+    EXPECT_EQ(driver200->carBrand, "MultiBrand 1");
 
-    auto driver201 = integrator.findDriver("TK-201");
+    auto orders200 = integrator.ordersForDriver("VM-200");
+    ASSERT_EQ(orders200.size(), 3u);
+    EXPECT_EQ(orders200[0].address, "Multiple Hub 1A");
+    EXPECT_EQ(orders200[1].address, "Multiple Hub 1B");
+    EXPECT_EQ(orders200[2].address, "Multiple Hub 1C");
+
+    auto driver201 = integrator.findDriver("VM-201");
     ASSERT_TRUE(driver201.has_value());
-    EXPECT_EQ(driver201->fio, "Petrova Anna");
-    EXPECT_EQ(driver201->carBrand, "Skoda");
+    EXPECT_EQ(driver201->carBrand, "MultiBrand 2");
 
-    auto orders200 = integrator.ordersForDriver("TK-200");
-    ASSERT_EQ(orders200.size(), 2u);
-    EXPECT_EQ(orders200[0].address, "Nevsky 10");
-    EXPECT_EQ(orders200[1].address, "Sadovaya 33");
+    auto orders201 = integrator.ordersForDriver("VM-201");
+    ASSERT_EQ(orders201.size(), 2u);
+    EXPECT_EQ(orders201[0].address, "Multiple Hub 2A");
+    EXPECT_EQ(orders201[1].address, "Multiple Hub 2B");
 
-    auto orders201 = integrator.ordersForDriver("TK-201");
-    ASSERT_EQ(orders201.size(), 1u);
-    EXPECT_EQ(orders201[0].address, "Mira 20");
+    EXPECT_TRUE(integrator.ordersForDriver("VM-247").empty());
+    EXPECT_TRUE(integrator.ordersForDriver("VM-248").empty());
+    EXPECT_TRUE(integrator.ordersForDriver("VM-249").empty());
 }
 
 TEST(DataIntegratorTest, IntegratorLoadsConfigNoOrders) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_no_orders.cfg").string()));
 
-    EXPECT_EQ(integrator.driverCount(), 2u);
+    EXPECT_EQ(integrator.driverCount(), 50u);
     EXPECT_EQ(integrator.orderCount(), 0u);
 
-    auto driver300 = integrator.findDriver("TK-300");
+    auto driver300 = integrator.findDriver("VN-300");
     ASSERT_TRUE(driver300.has_value());
-    EXPECT_EQ(driver300->carBrand, "Hyundai");
+    EXPECT_EQ(driver300->carBrand, "CalmBrand 1");
 
-    auto driver301 = integrator.findDriver("TK-301");
-    ASSERT_TRUE(driver301.has_value());
-    EXPECT_EQ(driver301->fio, "Semenova Olga");
+    auto driver349 = integrator.findDriver("VN-349");
+    ASSERT_TRUE(driver349.has_value());
+    EXPECT_EQ(driver349->fio, "NoOrder Driver 50");
 
-    EXPECT_TRUE(integrator.ordersForDriver("TK-300").empty());
-    EXPECT_TRUE(integrator.ordersForDriver("TK-301").empty());
+    EXPECT_TRUE(integrator.ordersForDriver("VN-300").empty());
+    EXPECT_TRUE(integrator.ordersForDriver("VN-349").empty());
 }
 
 TEST(DataIntegratorTest, IntegratorSavesToFile) {
@@ -238,7 +253,7 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
 
-    auto driver = integrator.findDriver("TK-100");
+    auto driver = integrator.findDriver("VB-100");
     ASSERT_TRUE(driver.has_value());
     driver->carBrand = "UpdatedBrand";
     driver->originalLine = 15;
@@ -252,9 +267,10 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     updatedOrder.cost = "2700";
     EXPECT_TRUE(integrator.updateOrder(original, updatedOrder));
 
+    std::size_t initialOrderCount = integrator.orderCount();
     OrderRecord newOrder{driver->licenseNumber, "Tverskaya 5", "3100", "2025-01-15"};
     ASSERT_TRUE(integrator.addOrder(newOrder));
-    EXPECT_EQ(integrator.orderCount(), 2u);
+    EXPECT_EQ(integrator.orderCount(), initialOrderCount + 1);
 
     auto tempPath = TempFilePathForCurrentTest();
     RemoveIfExists(tempPath);
@@ -273,6 +289,62 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     EXPECT_NE(reloadedOrders.end(), std::find(reloadedOrders.begin(), reloadedOrders.end(), newOrder));
 
     RemoveIfExists(tempPath);
+}
+
+TEST(DataIntegratorTest, IntegratorDumpsStructuresToText) {
+    DataIntegrator integrator;
+    DriverRecord alpha{"DL-HASH-1", "Alpha Tester", "Tesla", 1};
+    DriverRecord beta{"DL-HASH-2", "Beta Tester", "Audi", 2};
+    DriverRecord gamma{"DL-HASH-3", "Gamma Tester", "BMW", 3};
+
+    ASSERT_TRUE(integrator.addDriver(alpha));
+    ASSERT_TRUE(integrator.addDriver(beta));
+    ASSERT_TRUE(integrator.addDriver(gamma));
+
+    OrderRecord orderA{alpha.licenseNumber, "Alpha Street", "100", "2025-04-01"};
+    OrderRecord orderB{beta.licenseNumber, "Beta Street", "200", "2025-04-02"};
+    OrderRecord orderC{gamma.licenseNumber, "Gamma Street", "300", "2025-04-03"};
+    OrderRecord orderD{alpha.licenseNumber, "Alpha Avenue", "400", "2025-04-04"};
+
+    ASSERT_TRUE(integrator.addOrder(orderA));
+    ASSERT_TRUE(integrator.addOrder(orderB));
+    ASSERT_TRUE(integrator.addOrder(orderC));
+    ASSERT_TRUE(integrator.addOrder(orderD));
+
+    auto hashDump = integrator.hashTableAsText();
+    EXPECT_NE(hashDump.find("HashTable dump"), std::string::npos);
+    EXPECT_NE(hashDump.find(alpha.licenseNumber), std::string::npos);
+
+    auto treeDump = integrator.orderTreeAsText();
+    EXPECT_NE(treeDump.find(alpha.licenseNumber), std::string::npos);
+    EXPECT_NE(treeDump.find("|--"), std::string::npos);
+
+    auto basePath = TempFilePathForCurrentTest();
+    auto hashPath = basePath;
+    hashPath += ".hash";
+    auto treePath = basePath;
+    treePath += ".tree";
+
+    RemoveIfExists(hashPath);
+    RemoveIfExists(treePath);
+
+    ASSERT_TRUE(integrator.saveStructures(hashPath.string(), ""));
+    std::ifstream hashInput(hashPath);
+    ASSERT_TRUE(hashInput.is_open());
+    std::ostringstream hashBuffer;
+    hashBuffer << hashInput.rdbuf();
+    EXPECT_EQ(hashBuffer.str(), hashDump);
+    hashInput.close();
+    RemoveIfExists(hashPath);
+
+    ASSERT_TRUE(integrator.saveStructures("", treePath.string()));
+    std::ifstream treeInput(treePath);
+    ASSERT_TRUE(treeInput.is_open());
+    std::ostringstream treeBuffer;
+    treeBuffer << treeInput.rdbuf();
+    EXPECT_EQ(treeBuffer.str(), treeDump);
+    treeInput.close();
+    RemoveIfExists(treePath);
 }
 
 TEST(DataIntegratorTest, IntegratorRejectsInvalidConfigFile) {

--- a/tests/tree_test.cpp
+++ b/tests/tree_test.cpp
@@ -55,3 +55,18 @@ TEST(AVLTreeTest, InorderTraversal) {
     EXPECT_EQ(nodes[2]->key.licenseNumber, "c");
     avl_free(&tree);
 }
+
+TEST(AVLTreeTest, DumpToStringContainsBranching) {
+    AVLTree tree;
+    avl_init(&tree);
+    avl_insert(&tree, {"m", "mid", "1", "2025"}, 0);
+    avl_insert(&tree, {"a", "left", "1", "2025"}, 1);
+    avl_insert(&tree, {"z", "right", "1", "2025"}, 2);
+
+    std::string dump = avl_tree_to_string(&tree);
+    EXPECT_NE(dump.find("m | mid"), std::string::npos);
+    EXPECT_NE(dump.find("|--"), std::string::npos);
+    EXPECT_NE(dump.find("`--"), std::string::npos);
+
+    avl_free(&tree);
+}


### PR DESCRIPTION
## Summary
- add string-based dump helpers to the hash table, AVL tree and data integrator so their state can be written to files
- expand the valid integrator configuration fixtures to 50 entries and refresh the loader tests accordingly
- cover the new functionality with unit tests for the hash table, AVL tree, and data integrator text dumps

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d0d3ec95c48324846de5491347fcd8