### PR TITLE
Refine data structures and integrator workflows

### DIFF
--- a/avl_tree.cpp
+++ b/avl_tree.cpp
@@ -49,17 +49,15 @@ static AVLNode* rotate_left(AVLNode* x) {
     return y;
 }
 
-static int key_compare(const OrderRecord& a, const OrderRecord& b) {
-    if (a.licenseNumber < b.licenseNumber) return -1;
-    if (a.licenseNumber > b.licenseNumber) return 1;
-    if (a.address < b.address) return -1;
-    if (a.address > b.address) return 1;
+static int key_compare(const std::string& a, const std::string& b) {
+    if (a < b) return -1;
+    if (a > b) return 1;
     return 0;
 }
 
-static AVLNode* create_node(const OrderRecord& key, std::size_t listIndex) {
+static AVLNode* create_node(const std::string& license, std::size_t listIndex) {
     AVLNode* node = new AVLNode;
-    node->key = key;
+    node->license = license;
     node->height = 1;
     node->left = 0;
     node->right = 0;
@@ -98,15 +96,15 @@ static AVLNode* min_node(AVLNode* node) {
     return node;
 }
 
-static AVLNode* insert_node(AVLNode* node, const OrderRecord& key, std::size_t listIndex) {
-    if (!node) return create_node(key, listIndex);
+static AVLNode* insert_node(AVLNode* node, const std::string& license, std::size_t listIndex) {
+    if (!node) return create_node(license, listIndex);
 
-    int cmp = key_compare(key, node->key);
+    int cmp = key_compare(license, node->license);
     if (cmp < 0) {
-        node->left = insert_node(node->left, key, listIndex);
+        node->left = insert_node(node->left, license, listIndex);
     }
     else if (cmp > 0) {
-        node->right = insert_node(node->right, key, listIndex);
+        node->right = insert_node(node->right, license, listIndex);
     }
     else {
         node->listIndices.push_back(listIndex);
@@ -116,15 +114,15 @@ static AVLNode* insert_node(AVLNode* node, const OrderRecord& key, std::size_t l
     return balance_node(node);
 }
 
-static AVLNode* remove_node(AVLNode* node, const OrderRecord& key, bool& removed) {
+static AVLNode* remove_node(AVLNode* node, const std::string& license, bool& removed) {
     if (!node) return 0;
 
-    int cmp = key_compare(key, node->key);
+    int cmp = key_compare(license, node->license);
     if (cmp < 0) {
-        node->left = remove_node(node->left, key, removed);
+        node->left = remove_node(node->left, license, removed);
     }
     else if (cmp > 0) {
-        node->right = remove_node(node->right, key, removed);
+        node->right = remove_node(node->right, license, removed);
     }
     else {
         removed = true;
@@ -140,19 +138,19 @@ static AVLNode* remove_node(AVLNode* node, const OrderRecord& key, bool& removed
         }
         bool dummy = false;
         AVLNode* temp = min_node(node->right);
-        node->key = temp->key;
+        node->license = temp->license;
         node->listIndices = temp->listIndices;
-        node->right = remove_node(node->right, temp->key, dummy);
+        node->right = remove_node(node->right, temp->license, dummy);
     }
 
     return balance_node(node);
 }
 
-static AVLNode* search_node(AVLNode* node, const OrderRecord& key) {
+static AVLNode* search_node(AVLNode* node, const std::string& license) {
     if (!node) return 0;
-    int cmp = key_compare(key, node->key);
-    if (cmp < 0) return search_node(node->left, key);
-    else if (cmp > 0) return search_node(node->right, key);
+    int cmp = key_compare(license, node->license);
+    if (cmp < 0) return search_node(node->left, license);
+    else if (cmp > 0) return search_node(node->right, license);
     else return node;
 }
 
@@ -174,22 +172,22 @@ void avl_init(AVLTree* tree) {
     tree->root = 0;
 }
 
-void avl_insert(AVLTree* tree, const OrderRecord& key, std::size_t listIndex) {
-    tree->root = insert_node(tree->root, key, listIndex);
+void avl_insert(AVLTree* tree, const std::string& license, std::size_t listIndex) {
+    tree->root = insert_node(tree->root, license, listIndex);
 }
 
-bool avl_remove(AVLTree* tree, const OrderRecord& key) {
+bool avl_remove(AVLTree* tree, const std::string& license) {
     bool removed = false;
-    tree->root = remove_node(tree->root, key, removed);
+    tree->root = remove_node(tree->root, license, removed);
     return removed;
 }
 
-AVLNode* avl_search(AVLTree* tree, const OrderRecord& key) {
-    return search_node(tree->root, key);
+AVLNode* avl_search(AVLTree* tree, const std::string& license) {
+    return search_node(tree->root, license);
 }
 
-const AVLNode* avl_search(const AVLTree* tree, const OrderRecord& key) {
-    return search_node(tree->root, key);
+const AVLNode* avl_search(const AVLTree* tree, const std::string& license) {
+    return search_node(tree->root, license);
 }
 
 std::vector<AVLNode*> avl_inorder_nodes(const AVLTree* tree) {
@@ -203,37 +201,40 @@ void avl_free(AVLTree* tree) {
     tree->root = 0;
 }
 
-bool avl_remove_index(AVLTree* tree, const OrderRecord& key, std::size_t listIndex) {
-    AVLNode* node = avl_search(tree, key);
+bool avl_remove_index(AVLTree* tree, const std::string& license, std::size_t listIndex) {
+    AVLNode* node = avl_search(tree, license);
     if (!node) {
         return false;
     }
 
-    auto it = std::find(node->listIndices.begin(), node->listIndices.end(), listIndex);
-    if (it == node->listIndices.end()) {
-        return false;
-    }
-
-    node->listIndices.erase(it);
-
-    if (node->listIndices.empty()) {
-        return avl_remove(tree, key);
-    }
-
-    return true;
-}
-
-bool avl_replace_index(AVLTree* tree, const OrderRecord& key, std::size_t oldIndex, std::size_t newIndex) {
-    AVLNode* node = avl_search(tree, key);
-    if (!node) {
-        return false;
-    }
-
-    for (std::size_t& idx : node->listIndices) {
-        if (idx == oldIndex) {
-            idx = newIndex;
+    std::list<std::size_t>::iterator it = node->listIndices.begin();
+    while (it != node->listIndices.end()) {
+        if (*it == listIndex) {
+            node->listIndices.erase(it);
+            if (node->listIndices.empty()) {
+                return avl_remove(tree, license);
+            }
             return true;
         }
+        ++it;
+    }
+
+    return false;
+}
+
+bool avl_replace_index(AVLTree* tree, const std::string& license, std::size_t oldIndex, std::size_t newIndex) {
+    AVLNode* node = avl_search(tree, license);
+    if (!node) {
+        return false;
+    }
+
+    std::list<std::size_t>::iterator it = node->listIndices.begin();
+    while (it != node->listIndices.end()) {
+        if (*it == oldIndex) {
+            *it = newIndex;
+            return true;
+        }
+        ++it;
     }
 
     return false;
@@ -255,16 +256,18 @@ void tree_to_stream(const AVLNode* node,
         out << (isTail ? "`--" : "|--");
     }
 
-    out << node->key.licenseNumber << " | "
-        << node->key.address << " | "
-        << node->key.cost << " | "
-        << node->key.date;
+    out << node->license;
 
     if (!node->listIndices.empty()) {
         out << " [";
-        for (std::size_t i = 0; i < node->listIndices.size(); ++i) {
-            out << node->listIndices[i];
-            if (i + 1 < node->listIndices.size()) {
+        std::size_t total = node->listIndices.size();
+        std::size_t position = 0;
+        std::list<std::size_t>::const_iterator it = node->listIndices.begin();
+        while (it != node->listIndices.end()) {
+            out << *it;
+            ++position;
+            ++it;
+            if (position < total) {
                 out << ",";
             }
         }

--- a/avl_tree.h
+++ b/avl_tree.h
@@ -2,17 +2,16 @@
 #define AVL_TREE_H
 
 #include <cstddef>
+#include <list>
 #include <string>
 #include <vector>
 
-#include "order_record.hpp"
-
 struct AVLNode {
-    OrderRecord key;
+    std::string              license;
     int         height;
     AVLNode*    left;
     AVLNode*    right;
-    std::vector<std::size_t> listIndices;
+    std::list<std::size_t>   listIndices;
 };
 
 struct AVLTree {
@@ -21,19 +20,19 @@ struct AVLTree {
 
 void avl_init(AVLTree* tree);
 
-void avl_insert(AVLTree* tree, const OrderRecord& key, std::size_t listIndex);
+void avl_insert(AVLTree* tree, const std::string& license, std::size_t listIndex);
 
-bool avl_remove(AVLTree* tree, const OrderRecord& key);
+bool avl_remove(AVLTree* tree, const std::string& license);
 
-AVLNode* avl_search(AVLTree* tree, const OrderRecord& key);
-const AVLNode* avl_search(const AVLTree* tree, const OrderRecord& key);
+AVLNode* avl_search(AVLTree* tree, const std::string& license);
+const AVLNode* avl_search(const AVLTree* tree, const std::string& license);
 
 std::vector<AVLNode*> avl_inorder_nodes(const AVLTree* tree);
 void avl_free(AVLTree* tree);
 
-bool avl_remove_index(AVLTree* tree, const OrderRecord& key, std::size_t listIndex);
+bool avl_remove_index(AVLTree* tree, const std::string& license, std::size_t listIndex);
 
-bool avl_replace_index(AVLTree* tree, const OrderRecord& key, std::size_t oldIndex, std::size_t newIndex);
+bool avl_replace_index(AVLTree* tree, const std::string& license, std::size_t oldIndex, std::size_t newIndex);
 
 std::string avl_tree_to_string(const AVLTree* tree);
 

--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1,12 +1,9 @@
 ﻿#include "data_integrator.hpp"
 
-#include <algorithm>
 #include <cstdio>
 #include <fstream>
-#include <set>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 namespace {
 
@@ -16,26 +13,30 @@ void trimCarriageReturn(std::string& value) {
     }
 }
 
-std::vector<std::string> splitLine(const std::string& line, char delimiter) {
-    std::vector<std::string> result;
-    std::string current;
-    for (char ch : line) {
-        if (ch == delimiter) {
-            result.push_back(current);
-            current.clear();
+bool splitLine(const std::string& line, char delimiter, std::string* fields, std::size_t expectedCount) {
+    std::size_t fieldIndex = 0;
+    std::size_t start = 0;
+    std::size_t length = line.size();
+    for (std::size_t i = 0; i <= length; ++i) {
+        bool isDelimiter = (i < length && line[i] == delimiter);
+        bool isEnd = (i == length);
+        if (!isDelimiter && !isEnd) {
+            continue;
         }
-        else {
-            current.push_back(ch);
+        if (fieldIndex >= expectedCount) {
+            return false;
         }
+        fields[fieldIndex] = line.substr(start, i - start);
+        ++fieldIndex;
+        start = i + 1;
     }
-    result.push_back(current);
-    return result;
+    return fieldIndex == expectedCount;
 }
 
 bool parseDriverLine(const std::string& line, DriverRecord& out) {
-    auto parts = splitLine(line, '|');
-    if (parts.size() != 4) return false;
-    for (auto& part : parts) trimCarriageReturn(part);
+    std::string parts[4];
+    if (!splitLine(line, '|', parts, 4)) return false;
+    for (std::size_t i = 0; i < 4; ++i) trimCarriageReturn(parts[i]);
 
     std::size_t consumed = 0;
     int originalLine = 0;
@@ -49,24 +50,24 @@ bool parseDriverLine(const std::string& line, DriverRecord& out) {
 
     if (parts[0].empty()) return false;
 
-    out.licenseNumber = std::move(parts[0]);
-    out.fio = std::move(parts[1]);
-    out.carBrand = std::move(parts[2]);
+    out.licenseNumber = parts[0];
+    out.fio = parts[1];
+    out.carBrand = parts[2];
     out.originalLine = originalLine;
     return true;
 }
 
 bool parseOrderLine(const std::string& line, OrderRecord& out) {
-    auto parts = splitLine(line, '|');
-    if (parts.size() != 4) return false;
-    for (auto& part : parts) trimCarriageReturn(part);
+    std::string parts[4];
+    if (!splitLine(line, '|', parts, 4)) return false;
+    for (std::size_t i = 0; i < 4; ++i) trimCarriageReturn(parts[i]);
 
     if (parts[0].empty()) return false;
 
-    out.licenseNumber = std::move(parts[0]);
-    out.address = std::move(parts[1]);
-    out.cost = std::move(parts[2]);
-    out.date = std::move(parts[3]);
+    out.licenseNumber = parts[0];
+    out.address = parts[1];
+    out.cost = parts[2];
+    out.date = parts[3];
     return true;
 }
 
@@ -81,6 +82,7 @@ DataIntegrator::DataIntegrator(std::size_t driverTableInitialSize, double maxLoa
 }
 
 bool DataIntegrator::addDriver(const DriverRecord& record) {
+    if (!validateDriverRecord(record)) return false;
     if (driverTable_.contains(record.licenseNumber)) return false;
 
     std::size_t index = drivers_.push_back(record);
@@ -92,16 +94,17 @@ bool DataIntegrator::addDriver(const DriverRecord& record) {
     return true;
 }
 
-bool DataIntegrator::removeDriver(const std::string& licenseNumber) {
-    auto driverIdxOpt = findDriverIndex(licenseNumber);
-    if (!driverIdxOpt) return false;
-    std::size_t driverIdx = *driverIdxOpt;
+bool DataIntegrator::removeDriver(const DriverRecord& record) {
+    std::optional<std::size_t> driverIdxOpt = findDriverIndex(record);
+    if (!driverIdxOpt.has_value()) return false;
+    std::size_t driverIdx = driverIdxOpt.value();
+    std::string licenseNumber = record.licenseNumber;
 
     for (std::size_t i = orders_.size(); i > 0; --i) {
         std::size_t orderIdx = i - 1;
         OrderRecord order = orders_.at(orderIdx);
         if (order.licenseNumber == licenseNumber) {
-            removeOrderByIndex(order, orderIdx);
+            removeOrderByIndex(order.licenseNumber, orderIdx);
         }
     }
 
@@ -118,14 +121,28 @@ bool DataIntegrator::removeDriver(const std::string& licenseNumber) {
     return true;
 }
 
-bool DataIntegrator::updateDriver(const std::string& licenseNumber, const DriverRecord& updated) {
-    auto driverIdxOpt = findDriverIndex(licenseNumber);
-    if (!driverIdxOpt) return false;
-    if (updated.licenseNumber != licenseNumber) return false;
+bool DataIntegrator::removeDriver(const std::string& licenseNumber) {
+    std::optional<DriverRecord> stored = findDriver(licenseNumber);
+    if (!stored.has_value()) return false;
+    return removeDriver(stored.value());
+}
 
-    DriverRecord& stored = drivers_.at(*driverIdxOpt);
+bool DataIntegrator::updateDriver(const DriverRecord& current, const DriverRecord& updated) {
+    if (!validateDriverRecord(updated)) return false;
+    if (current.licenseNumber != updated.licenseNumber) return false;
+
+    std::optional<std::size_t> driverIdxOpt = findDriverIndex(current);
+    if (!driverIdxOpt.has_value()) return false;
+
+    DriverRecord& stored = drivers_.at(driverIdxOpt.value());
     stored = updated;
     return true;
+}
+
+bool DataIntegrator::updateDriver(const std::string& licenseNumber, const DriverRecord& updated) {
+    std::optional<DriverRecord> stored = findDriver(licenseNumber);
+    if (!stored.has_value()) return false;
+    return updateDriver(stored.value(), updated);
 }
 
 
@@ -133,40 +150,47 @@ bool DataIntegrator::hasDriver(const std::string& licenseNumber) const {
     return driverTable_.contains(licenseNumber);
 }
 
+std::optional<DriverRecord> DataIntegrator::findDriver(const DriverRecord& record) const {
+    std::optional<std::size_t> driverIdxOpt = findDriverIndex(record);
+    if (!driverIdxOpt.has_value()) return std::nullopt;
+    return drivers_.at(driverIdxOpt.value());
+}
+
 std::optional<DriverRecord> DataIntegrator::findDriver(const std::string& licenseNumber) const {
-    auto driverIdxOpt = findDriverIndex(licenseNumber);
-    if (!driverIdxOpt) return std::nullopt;
-    return drivers_.at(*driverIdxOpt);
+    std::optional<std::size_t> driverIdxOpt = findDriverIndex(licenseNumber);
+    if (!driverIdxOpt.has_value()) return std::nullopt;
+    return drivers_.at(driverIdxOpt.value());
 }
 
 bool DataIntegrator::addOrder(const OrderRecord& record) {
+    if (!validateOrderRecord(record)) return false;
     if (!driverTable_.contains(record.licenseNumber)) return false;
 
     std::size_t index = orders_.push_back(record);
-    avl_insert(&orderTree_, record, index);
+    avl_insert(&orderTree_, record.licenseNumber, index);
     return true;
 }
 
 bool DataIntegrator::removeOrder(const OrderRecord& record) {
-    auto idxOpt = findOrderIndex(record, &record);
-    if (!idxOpt) return false;
-    removeOrderByIndex(record, *idxOpt);
+    std::optional<std::size_t> idxOpt = findOrderIndex(record, &record);
+    if (!idxOpt.has_value()) return false;
+    removeOrderByIndex(record.licenseNumber, idxOpt.value());
     return true;
 }
 
 bool DataIntegrator::updateOrder(const OrderRecord& current, const OrderRecord& updated) {
-    auto idxOpt = findOrderIndex(current, &current);
-    if (!idxOpt) return false;
+    std::optional<std::size_t> idxOpt = findOrderIndex(current, &current);
+    if (!idxOpt.has_value()) return false;
 
+    if (!validateOrderRecord(updated)) return false;
     if (!driverTable_.contains(updated.licenseNumber)) return false;
 
-    std::size_t idx = *idxOpt;
-    bool keyChanged = current.licenseNumber != updated.licenseNumber ||
-                      current.address != updated.address;
+    std::size_t idx = idxOpt.value();
+    bool licenseChanged = current.licenseNumber != updated.licenseNumber;
 
-    if (keyChanged) {
-        avl_remove_index(&orderTree_, current, idx);
-        avl_insert(&orderTree_, updated, idx);
+    if (licenseChanged) {
+        avl_remove_index(&orderTree_, current.licenseNumber, idx);
+        avl_insert(&orderTree_, updated.licenseNumber, idx);
     }
 
     orders_.at(idx) = updated;
@@ -174,7 +198,8 @@ bool DataIntegrator::updateOrder(const OrderRecord& current, const OrderRecord& 
 }
 
 bool DataIntegrator::hasOrder(const OrderRecord& record) const {
-    return findOrderIndex(record, &record).has_value();
+    std::optional<std::size_t> idxOpt = findOrderIndex(record, &record);
+    return idxOpt.has_value();
 }
 
 std::vector<OrderRecord> DataIntegrator::ordersForDriver(const std::string& licenseNumber) const {
@@ -208,16 +233,12 @@ bool DataIntegrator::loadFromFile(const std::string& path) {
     std::string line;
     std::getline(input, line); // consume the rest of the header line
 
-    std::vector<DriverRecord> parsedDrivers;
-    parsedDrivers.reserve(driverCount);
-    std::set<std::string> licenseNumbers;
-
+    DoublyLinkedList<DriverRecord> parsedDrivers;
     for (std::size_t i = 0; i < driverCount; ++i) {
         if (!std::getline(input, line)) return false;
         DriverRecord record{};
         if (!parseDriverLine(line, record)) return false;
-        if (!licenseNumbers.insert(record.licenseNumber).second) return false;
-        parsedDrivers.push_back(std::move(record));
+        parsedDrivers.push_back(record);
     }
 
     long long orderCountRaw = 0;
@@ -226,33 +247,48 @@ bool DataIntegrator::loadFromFile(const std::string& path) {
     std::size_t orderCount = static_cast<std::size_t>(orderCountRaw);
     std::getline(input, line);
 
-    std::vector<OrderRecord> parsedOrders;
-    parsedOrders.reserve(orderCount);
-
+    DoublyLinkedList<OrderRecord> parsedOrders;
     for (std::size_t i = 0; i < orderCount; ++i) {
         if (!std::getline(input, line)) return false;
         OrderRecord record{};
         if (!parseOrderLine(line, record)) return false;
-        if (licenseNumbers.find(record.licenseNumber) == licenseNumbers.end()) return false;
-        parsedOrders.push_back(std::move(record));
+        parsedOrders.push_back(record);
+    }
+
+    DataIntegrator temp(driverTable_.capacity());
+
+    bool driversLoaded = true;
+    parsedDrivers.for_each([&temp, &driversLoaded](const DriverRecord& driver, std::size_t) {
+        if (!driversLoaded) {
+            return;
+        }
+        if (!temp.addDriver(driver)) {
+            driversLoaded = false;
+        }
+    });
+    if (!driversLoaded) {
+        return false;
+    }
+
+    bool ordersLoaded = true;
+    parsedOrders.for_each([&temp, &ordersLoaded](const OrderRecord& order, std::size_t) {
+        if (!ordersLoaded) {
+            return;
+        }
+        if (!temp.addOrder(order)) {
+            ordersLoaded = false;
+        }
+    });
+    if (!ordersLoaded) {
+        return false;
     }
 
     clear();
-
-    for (const auto& driver : parsedDrivers) {
-        if (!addDriver(driver)) {
-            clear();
-            return false;
-        }
-    }
-
-    for (const auto& order : parsedOrders) {
-        if (!addOrder(order)) {
-            clear();
-            return false;
-        }
-    }
-
+    drivers_ = std::move(temp.drivers_);
+    orders_ = std::move(temp.orders_);
+    driverTable_ = std::move(temp.driverTable_);
+    orderTree_ = temp.orderTree_;
+    temp.orderTree_.root = nullptr;
     return true;
 }
 
@@ -315,15 +351,27 @@ std::optional<std::size_t> DataIntegrator::findDriverIndex(const std::string& li
     return index;
 }
 
+std::optional<std::size_t> DataIntegrator::findDriverIndex(const DriverRecord& record) const {
+    std::optional<std::size_t> indexOpt = findDriverIndex(record.licenseNumber);
+    if (!indexOpt.has_value()) return std::nullopt;
+    const DriverRecord& stored = drivers_.at(indexOpt.value());
+    if (stored == record) {
+        return indexOpt;
+    }
+    return std::nullopt;
+}
+
 std::optional<std::size_t> DataIntegrator::findOrderIndex(const OrderRecord& key, const OrderRecord* match) const {
-    const AVLNode* node = avl_search(&orderTree_, key);
+    const AVLNode* node = avl_search(&orderTree_, key.licenseNumber);
     if (!node) return std::nullopt;
     if (!match) {
         if (node->listIndices.empty()) return std::nullopt;
         return node->listIndices.front();
     }
 
-    for (std::size_t idx : node->listIndices) {
+    std::list<std::size_t>::const_iterator it = node->listIndices.begin();
+    while (it != node->listIndices.end()) {
+        std::size_t idx = *it;
         const OrderRecord& stored = orders_.at(idx);
         if (stored.licenseNumber == match->licenseNumber &&
             stored.address == match->address &&
@@ -331,20 +379,37 @@ std::optional<std::size_t> DataIntegrator::findOrderIndex(const OrderRecord& key
             stored.date == match->date) {
             return idx;
         }
+        ++it;
     }
     return std::nullopt;
 }
 
-void DataIntegrator::removeOrderByIndex(const OrderRecord& key, std::size_t index) {
+void DataIntegrator::removeOrderByIndex(const std::string& licenseNumber, std::size_t index) {
     DoublyLinkedList<OrderRecord>::SwapRemoveResult result;
     if (!orders_.remove_by_index(index, result)) return;
 
-    avl_remove_index(&orderTree_, key, index);
+    avl_remove_index(&orderTree_, licenseNumber, index);
 
     if (result.swapped && orders_.size() > index) {
         OrderRecord& movedOrder = orders_.at(index);
-        avl_replace_index(&orderTree_, movedOrder, result.swappedFromIndex, index);
+        avl_replace_index(&orderTree_, movedOrder.licenseNumber, result.swappedFromIndex, index);
     }
+}
+
+bool DataIntegrator::validateDriverRecord(const DriverRecord& record) const {
+    if (record.licenseNumber.empty()) return false;
+    if (record.fio.empty()) return false;
+    if (record.carBrand.empty()) return false;
+    if (record.originalLine < -1) return false;
+    return true;
+}
+
+bool DataIntegrator::validateOrderRecord(const OrderRecord& record) const {
+    if (record.licenseNumber.empty()) return false;
+    if (record.address.empty()) return false;
+    if (record.cost.empty()) return false;
+    if (record.date.empty()) return false;
+    return true;
 }
 
 

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -15,9 +15,12 @@ public:
     explicit DataIntegrator(std::size_t driverTableInitialSize = 32, double maxLoadFactor = 0.75);
 
     bool addDriver(const DriverRecord& record);
+    bool removeDriver(const DriverRecord& record);
     bool removeDriver(const std::string& licenseNumber);
+    bool updateDriver(const DriverRecord& current, const DriverRecord& updated);
     bool updateDriver(const std::string& licenseNumber, const DriverRecord& updated);
     bool hasDriver(const std::string& licenseNumber) const;
+    std::optional<DriverRecord> findDriver(const DriverRecord& record) const;
     std::optional<DriverRecord> findDriver(const std::string& licenseNumber) const;
 
     bool addOrder(const OrderRecord& record);
@@ -44,6 +47,9 @@ private:
     AVLTree                        orderTree_;
 
     std::optional<std::size_t> findDriverIndex(const std::string& licenseNumber) const;
+    std::optional<std::size_t> findDriverIndex(const DriverRecord& record) const;
     std::optional<std::size_t> findOrderIndex(const OrderRecord& key, const OrderRecord* match) const;
-    void removeOrderByIndex(const OrderRecord& key, std::size_t index);
+    void removeOrderByIndex(const std::string& licenseNumber, std::size_t index);
+    bool validateDriverRecord(const DriverRecord& record) const;
+    bool validateOrderRecord(const OrderRecord& record) const;
 };

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -75,7 +75,7 @@ TEST(DataIntegratorTest, IntegratorCascadesDriverRemoval) {
     ASSERT_TRUE(integrator.addOrder(o2));
     EXPECT_EQ(integrator.orderCount(), 2u);
 
-    EXPECT_TRUE(integrator.removeDriver(driver.licenseNumber));
+    EXPECT_TRUE(integrator.removeDriver(driver));
     EXPECT_FALSE(integrator.hasDriver(driver.licenseNumber));
     EXPECT_EQ(integrator.orderCount(), 0u);
     EXPECT_FALSE(integrator.hasOrder(o1));
@@ -127,7 +127,7 @@ TEST(DataIntegratorTest, IntegratorUpdateDriverKeepsData) {
 
     DriverRecord updated = driver;
     updated.carBrand = "Tesla";
-    EXPECT_TRUE(integrator.updateDriver(driver.licenseNumber, updated));
+    EXPECT_TRUE(integrator.updateDriver(driver, updated));
     auto stored = integrator.findDriver(driver.licenseNumber);
     ASSERT_TRUE(stored.has_value());
     EXPECT_EQ(stored->carBrand, "Tesla");
@@ -253,13 +253,15 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
 
-    auto driver = integrator.findDriver("VB-100");
-    ASSERT_TRUE(driver.has_value());
-    driver->carBrand = "UpdatedBrand";
-    driver->originalLine = 15;
-    EXPECT_TRUE(integrator.updateDriver(driver->licenseNumber, *driver));
+    auto driverOpt = integrator.findDriver("VB-100");
+    ASSERT_TRUE(driverOpt.has_value());
+    DriverRecord originalDriver = *driverOpt;
+    DriverRecord updatedDriver = originalDriver;
+    updatedDriver.carBrand = "UpdatedBrand";
+    updatedDriver.originalLine = 15;
+    EXPECT_TRUE(integrator.updateDriver(originalDriver, updatedDriver));
 
-    auto existingOrders = integrator.ordersForDriver(driver->licenseNumber);
+    auto existingOrders = integrator.ordersForDriver(updatedDriver.licenseNumber);
     ASSERT_EQ(existingOrders.size(), 1u);
     OrderRecord original = existingOrders[0];
     OrderRecord updatedOrder = original;
@@ -268,7 +270,7 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     EXPECT_TRUE(integrator.updateOrder(original, updatedOrder));
 
     std::size_t initialOrderCount = integrator.orderCount();
-    OrderRecord newOrder{driver->licenseNumber, "Tverskaya 5", "3100", "2025-01-15"};
+    OrderRecord newOrder{updatedDriver.licenseNumber, "Tverskaya 5", "3100", "2025-01-15"};
     ASSERT_TRUE(integrator.addOrder(newOrder));
     EXPECT_EQ(integrator.orderCount(), initialOrderCount + 1);
 
@@ -278,12 +280,12 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
 
     DataIntegrator reloaded;
     ASSERT_TRUE(reloaded.loadFromFile(tempPath.string()));
-    auto reloadedDriver = reloaded.findDriver(driver->licenseNumber);
+    auto reloadedDriver = reloaded.findDriver(updatedDriver.licenseNumber);
     ASSERT_TRUE(reloadedDriver.has_value());
     EXPECT_EQ(reloadedDriver->carBrand, "UpdatedBrand");
     EXPECT_EQ(reloadedDriver->originalLine, 15);
 
-    auto reloadedOrders = reloaded.ordersForDriver(driver->licenseNumber);
+    auto reloadedOrders = reloaded.ordersForDriver(updatedDriver.licenseNumber);
     ASSERT_EQ(reloadedOrders.size(), 2u);
     EXPECT_NE(reloadedOrders.end(), std::find(reloadedOrders.begin(), reloadedOrders.end(), updatedOrder));
     EXPECT_NE(reloadedOrders.end(), std::find(reloadedOrders.begin(), reloadedOrders.end(), newOrder));

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -56,6 +56,10 @@ TEST(DataIntegratorUseCasesTest, UseCase02_AddNovikovaDriver) {
     auto stored = integrator.findDriver(driver.licenseNumber);
     ASSERT_TRUE(stored.has_value());
     EXPECT_EQ(*stored, driver);
+
+    auto storedByRecord = integrator.findDriver(driver);
+    ASSERT_TRUE(storedByRecord.has_value());
+    EXPECT_EQ(storedByRecord->fio, driver.fio);
 }
 
 TEST(DataIntegratorUseCasesTest, UseCase03_DuplicateDriverRejected) {
@@ -77,11 +81,12 @@ TEST(DataIntegratorUseCasesTest, UseCase04_LoadBasicAndUpdateDriver) {
     auto record = integrator.findDriver("VB-100");
     ASSERT_TRUE(record.has_value());
 
-    DriverRecord updated = *record;
+    DriverRecord original = *record;
+    DriverRecord updated = original;
     updated.carBrand = "UpdatedBrand";
     updated.originalLine = 15;
 
-    EXPECT_TRUE(integrator.updateDriver("VB-100", updated));
+    EXPECT_TRUE(integrator.updateDriver(original, updated));
 
     auto stored = integrator.findDriver("VB-100");
     ASSERT_TRUE(stored.has_value());
@@ -100,7 +105,7 @@ TEST(DataIntegratorUseCasesTest, UseCase05_DeleteDriverRemovesOrders) {
     ASSERT_TRUE(integrator.addOrder(orderB));
     EXPECT_EQ(integrator.orderCount(), 2u);
 
-    EXPECT_TRUE(integrator.removeDriver(driver.licenseNumber));
+    EXPECT_TRUE(integrator.removeDriver(driver));
     EXPECT_EQ(integrator.driverCount(), 0u);
     EXPECT_EQ(integrator.orderCount(), 0u);
     EXPECT_FALSE(integrator.hasOrder(orderA));
@@ -292,10 +297,11 @@ TEST(DataIntegratorUseCasesTest, UseCase21_UpdateOrderAndAddNewForDriver) {
     auto driver = integrator.findDriver("VB-100");
     ASSERT_TRUE(driver.has_value());
 
-    DriverRecord updatedDriver = *driver;
+    DriverRecord originalDriver = *driver;
+    DriverRecord updatedDriver = originalDriver;
     updatedDriver.carBrand = "UpdatedBrand";
     updatedDriver.originalLine = 15;
-    EXPECT_TRUE(integrator.updateDriver("VB-100", updatedDriver));
+    EXPECT_TRUE(integrator.updateDriver(originalDriver, updatedDriver));
 
     OrderRecord originalOrder{"VB-100", "Basic Street 1", "1000", "2024-12-01"};
     OrderRecord modified{"VB-100", "Prospekt Mira 10", "2700", "2024-12-01"};
@@ -357,7 +363,7 @@ TEST(DataIntegratorUseCasesTest, UseCase23_SaveEditsAndReload) {
 
     DriverRecord driver{"VB-100", "Basic Driver 1", "Brand 1", 1};
     DriverRecord updated{"VB-100", "Basic Driver 1", "UpdatedBrand", 15};
-    EXPECT_TRUE(integrator.updateDriver(driver.licenseNumber, updated));
+    EXPECT_TRUE(integrator.updateDriver(driver, updated));
 
     OrderRecord originalOrder{driver.licenseNumber, "Basic Street 1", "1000", "2024-12-01"};
     OrderRecord modifiedOrder{driver.licenseNumber, "Prospekt Mira 10", "2700", "2024-12-01"};
@@ -461,8 +467,8 @@ TEST(DataIntegratorUseCasesTest, UseCase28_ShowDiagnosticsDumps) {
 
     auto treeDump = integrator.orderTreeAsText();
     EXPECT_NE(treeDump.find("|--"), std::string::npos);
-    EXPECT_NE(treeDump.find("Alpha Street"), std::string::npos);
-    EXPECT_NE(treeDump.find("Alpha Avenue"), std::string::npos);
+    EXPECT_NE(treeDump.find("DL-HASH-1"), std::string::npos);
+    EXPECT_NE(treeDump.find("[0,3]"), std::string::npos);
 }
 
 TEST(DataIntegratorUseCasesTest, UseCase29_SaveDiagnosticsSeparately) {

--- a/tests/tree_test.cpp
+++ b/tests/tree_test.cpp
@@ -4,67 +4,67 @@
 TEST(AVLTreeTest, InsertAndSearch) {
     AVLTree tree;
     avl_init(&tree);
-    OrderRecord k{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
-    avl_insert(&tree, k, 10);
-    AVLNode* node = avl_search(&tree, k);
+    std::string license = "TK-25-111111-2023";
+    avl_insert(&tree, license, 10);
+    AVLNode* node = avl_search(&tree, license);
     ASSERT_NE(node, nullptr);
     ASSERT_EQ(node->listIndices.size(), 1u);
-    EXPECT_EQ(node->listIndices[0], 10u);
+    EXPECT_EQ(node->listIndices.front(), 10u);
     avl_free(&tree);
 }
 
 TEST(AVLTreeTest, Remove) {
     AVLTree tree;
     avl_init(&tree);
-    OrderRecord k1{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
-    OrderRecord k2{"TK-25-222222-2024", "Ul. Lenina", "500 r.", "07 jan 2025"};
-    avl_insert(&tree, k1, 1);
-    avl_insert(&tree, k2, 2);
-    EXPECT_TRUE(avl_remove(&tree, k1));
-    EXPECT_EQ(avl_search(&tree, k1), nullptr);
-    EXPECT_NE(avl_search(&tree, k2), nullptr);
+    std::string licenseOne = "TK-25-111111-2023";
+    std::string licenseTwo = "TK-25-222222-2024";
+    avl_insert(&tree, licenseOne, 1);
+    avl_insert(&tree, licenseTwo, 2);
+    EXPECT_TRUE(avl_remove(&tree, licenseOne));
+    EXPECT_EQ(avl_search(&tree, licenseOne), nullptr);
+    EXPECT_NE(avl_search(&tree, licenseTwo), nullptr);
     avl_free(&tree);
 }
 
 TEST(AVLTreeTest, RemoveIndex) {
     AVLTree tree;
     avl_init(&tree);
-    OrderRecord k{"TK-25-111111-2023", "Ul. Lesnaya", "300 r.", "02 jan 2025"};
-    avl_insert(&tree, k, 1);
-    avl_insert(&tree, k, 2);
-    EXPECT_TRUE(avl_remove_index(&tree, k, 1));
-    AVLNode* node = avl_search(&tree, k);
+    std::string license = "TK-25-111111-2023";
+    avl_insert(&tree, license, 1);
+    avl_insert(&tree, license, 2);
+    EXPECT_TRUE(avl_remove_index(&tree, license, 1));
+    AVLNode* node = avl_search(&tree, license);
     ASSERT_NE(node, nullptr);
     ASSERT_EQ(node->listIndices.size(), 1u);
-    EXPECT_EQ(node->listIndices[0], 2u);
-    EXPECT_TRUE(avl_remove_index(&tree, k, 2));
-    EXPECT_EQ(avl_search(&tree, k), nullptr);
+    EXPECT_EQ(node->listIndices.front(), 2u);
+    EXPECT_TRUE(avl_remove_index(&tree, license, 2));
+    EXPECT_EQ(avl_search(&tree, license), nullptr);
     avl_free(&tree);
 }
 
 TEST(AVLTreeTest, InorderTraversal) {
     AVLTree tree;
     avl_init(&tree);
-    avl_insert(&tree, {"b", "2", "1 r.", "01 jan 2025"}, 0);
-    avl_insert(&tree, {"a", "1", "1 r.", "01 jan 2025"}, 1);
-    avl_insert(&tree, {"c", "3", "1 r.", "01 jan 2025"}, 2);
+    avl_insert(&tree, "b", 0);
+    avl_insert(&tree, "a", 1);
+    avl_insert(&tree, "c", 2);
     auto nodes = avl_inorder_nodes(&tree);
     ASSERT_EQ(nodes.size(), 3u);
-    EXPECT_EQ(nodes[0]->key.licenseNumber, "a");
-    EXPECT_EQ(nodes[1]->key.licenseNumber, "b");
-    EXPECT_EQ(nodes[2]->key.licenseNumber, "c");
+    EXPECT_EQ(nodes[0]->license, "a");
+    EXPECT_EQ(nodes[1]->license, "b");
+    EXPECT_EQ(nodes[2]->license, "c");
     avl_free(&tree);
 }
 
 TEST(AVLTreeTest, DumpToStringContainsBranching) {
     AVLTree tree;
     avl_init(&tree);
-    avl_insert(&tree, {"m", "mid", "1", "2025"}, 0);
-    avl_insert(&tree, {"a", "left", "1", "2025"}, 1);
-    avl_insert(&tree, {"z", "right", "1", "2025"}, 2);
+    avl_insert(&tree, "m", 0);
+    avl_insert(&tree, "a", 1);
+    avl_insert(&tree, "z", 2);
 
     std::string dump = avl_tree_to_string(&tree);
-    EXPECT_NE(dump.find("m | mid"), std::string::npos);
+    EXPECT_NE(dump.find("m"), std::string::npos);
     EXPECT_NE(dump.find("|--"), std::string::npos);
     EXPECT_NE(dump.find("`--"), std::string::npos);
 


### PR DESCRIPTION
## Summary
- key the AVL tree by driver license strings and keep order indices in a list per node
- update the data integrator CRUD API to operate on full driver records, validate inputs, and rework file loading without vectors
- adjust unit tests to reflect the new APIs and tree representation

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d149eef8788324bb1fa51c807a51df