### PR TITLE
Add FLTK GUI for data integrator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,17 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+FetchContent_Declare(
+    fltk
+    URL https://github.com/fltk/fltk/archive/refs/tags/release-1.3.8.tar.gz
+)
+set(FLTK_BUILD_TEST OFF CACHE BOOL "" FORCE)
+set(FLTK_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(FLTK_BUILD_FLUID OFF CACHE BOOL "" FORCE)
+set(FLTK_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(fltk)
+FetchContent_GetProperties(fltk)
+
 add_executable(cursedarch_tests
     KursAch.cpp
     tests/doubly_linked_list_test.cpp
@@ -45,3 +56,19 @@ target_link_libraries(cursedarch_tests
 )
 
 add_test(NAME cursedarch_tests COMMAND cursedarch_tests)
+
+add_executable(integrator_gui
+    integrator_gui.cpp
+)
+
+target_link_libraries(integrator_gui
+    PRIVATE
+        cursedarch
+        fltk
+)
+
+target_include_directories(integrator_gui
+    PRIVATE
+        ${fltk_SOURCE_DIR}
+        ${fltk_BINARY_DIR}
+)

--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -2,8 +2,10 @@
 
 #include <cstdio>
 #include <fstream>
+#include <sstream>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace {
 
@@ -69,6 +71,61 @@ bool parseOrderLine(const std::string& line, OrderRecord& out) {
     out.cost = parts[2];
     out.date = parts[3];
     return true;
+}
+
+void appendOrderNodeDetailed(const AVLNode*                     node,
+                             const DoublyLinkedList<OrderRecord>& orders,
+                             std::ostringstream&                 out,
+                             const std::string&                  prefix,
+                             bool                                isTail,
+                             bool                                isRoot) {
+    if (!node) {
+        return;
+    }
+
+    out << prefix;
+    if (!isRoot) {
+        out << (isTail ? "`--" : "|--");
+    }
+    out << node->license << '\n';
+
+    std::string childPrefix = prefix;
+    if (!isRoot) {
+        childPrefix += (isTail ? "    " : "|   ");
+    }
+
+    if (node->listIndices.empty()) {
+        out << childPrefix << "• Заказов нет\n";
+    }
+    else {
+        for (std::list<std::size_t>::const_iterator it = node->listIndices.begin();
+             it != node->listIndices.end();
+             ++it) {
+            std::size_t listIndex = *it;
+            out << childPrefix << "• ";
+            if (listIndex < orders.size()) {
+                const OrderRecord& order = orders.at(listIndex);
+                out << order.address << " | " << order.cost << " | " << order.date;
+            }
+            else {
+                out << "(недопустимый индекс " << listIndex << ")";
+            }
+            out << '\n';
+        }
+    }
+
+    std::vector<const AVLNode*> children;
+    if (node->left) {
+        children.push_back(node->left);
+    }
+    if (node->right) {
+        children.push_back(node->right);
+    }
+
+    for (std::size_t i = 0; i < children.size(); ++i) {
+        bool childIsTail = (i + 1 == children.size());
+        appendOrderNodeDetailed(children[i], orders, out, childPrefix, childIsTail, false);
+    }
 }
 
 } // namespace
@@ -311,11 +368,52 @@ bool DataIntegrator::saveToFile(const std::string& path) const {
 }
 
 std::string DataIntegrator::hashTableAsText() const {
-    return driverTable_.toString();
+    std::ostringstream out;
+    out << "Водителей: " << drivers_.size()
+        << " | Вместимость таблицы: " << driverTable_.capacity()
+        << " | Записей: " << driverTable_.size() << '\n';
+    out << "----------------------------------------\n";
+
+    std::vector<HashTable::Entry> entries = driverTable_.entries();
+    if (entries.empty()) {
+        out << "(пусто)\n";
+        return out.str();
+    }
+
+    for (const HashTable::Entry& entry : entries) {
+        if (entry.index >= drivers_.size()) {
+            continue;
+        }
+        const DriverRecord& driver = drivers_.at(entry.index);
+        std::size_t        orderCount = 0;
+        orders_.for_each([&](const OrderRecord& order, std::size_t) {
+            if (order.licenseNumber == driver.licenseNumber) {
+                ++orderCount;
+            }
+        });
+
+        out << '[' << entry.slot << "] " << driver.licenseNumber
+            << " | ФИО: " << driver.fio
+            << " | Авто: " << driver.carBrand
+            << " | Строка: " << driver.originalLine
+            << " | Заказов: " << orderCount << '\n';
+    }
+
+    return out.str();
 }
 
 std::string DataIntegrator::orderTreeAsText() const {
-    return avl_tree_to_string(&orderTree_);
+    if (!orderTree_.root) {
+        std::ostringstream empty;
+        empty << "Заказов нет\n";
+        return empty.str();
+    }
+
+    std::ostringstream out;
+    out << "Всего заказов: " << orders_.size() << '\n';
+    out << "----------------------------------------\n";
+    appendOrderNodeDetailed(orderTree_.root, orders_, out, "", true, true);
+    return out.str();
 }
 
 bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std::string& treePath) const {

--- a/hashtable.cpp
+++ b/hashtable.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <sstream>
 #include <utility>
+#include <vector>
 
 Cell::Cell()
     : occupied(false), key(), index(0) {}
@@ -149,6 +150,18 @@ std::string HashTable::toString() const {
         out << "(no entries)\n";
     }
     return out.str();
+}
+
+std::vector<HashTable::Entry> HashTable::entries() const {
+    std::vector<Entry> result;
+    result.reserve(m_count);
+    for (std::size_t i = 0; i < m_size; ++i) {
+        if (!table[i].occupied) {
+            continue;
+        }
+        result.push_back(Entry{i, table[i].key, table[i].index});
+    }
+    return result;
 }
 
 std::size_t HashTable::hashPrimary(const std::string& key) const {

--- a/hashtable.hpp
+++ b/hashtable.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <string>
+#include <vector>
 
 struct Cell {
     bool        occupied;
@@ -13,6 +14,12 @@ struct Cell {
 
 class HashTable {
 public:
+    struct Entry {
+        std::size_t slot;
+        std::string key;
+        std::size_t index;
+    };
+
     explicit HashTable(std::size_t initialSize, double maxLoad = 0.75);
     HashTable(const HashTable&) = delete;
     HashTable& operator=(const HashTable&) = delete;
@@ -29,6 +36,7 @@ public:
 
     void clear();
     std::string toString() const;
+    std::vector<Entry> entries() const;
 
     std::size_t capacity() const { return m_size; }
     std::size_t size() const { return m_count; }

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -7,6 +7,7 @@
 #include <FL/Fl_Button.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
+#include <FL/Fl_Native_File_Chooser.H>
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
 #include <FL/fl_ask.H>
@@ -49,6 +50,10 @@ private:
     std::optional<DriverRecord> promptDriver(const DriverRecord* initial = nullptr);
     std::optional<OrderRecord>  promptOrder(const OrderRecord* initial = nullptr);
     std::optional<std::size_t>  promptIndexSelection(std::size_t count, const std::string& title);
+    std::optional<std::string>  promptFilePath(const char* dialogTitle,
+                                               const char* manualPrompt,
+                                               Fl_Native_File_Chooser::Type type,
+                                               bool allowEmpty = false);
 
     void handleLoad();
     void handleSave();
@@ -364,8 +369,42 @@ std::optional<std::size_t> IntegratorGUI::promptIndexSelection(std::size_t count
     }
 }
 
+std::optional<std::string> IntegratorGUI::promptFilePath(const char* dialogTitle,
+                                                         const char* manualPrompt,
+                                                         Fl_Native_File_Chooser::Type type,
+                                                         bool allowEmpty) {
+    Fl_Native_File_Chooser chooser(type);
+    chooser.title(dialogTitle);
+    if (type == Fl_Native_File_Chooser::BROWSE_SAVE_FILE) {
+        chooser.options(Fl_Native_File_Chooser::SAVEAS_CONFIRM);
+    }
+
+    int result = chooser.show();
+    if (result == 0) {
+        const char* filename = chooser.filename();
+        if (filename && *filename) {
+            return std::string(filename);
+        }
+        return allowEmpty ? std::optional<std::string>(std::string()) : std::nullopt;
+    }
+    if (result == 1) {
+        if (allowEmpty) {
+            return promptString(manualPrompt);
+        }
+        return promptNonEmpty(manualPrompt);
+    }
+
+    std::ostringstream error;
+    error << "Ошибка выбора файла: " << chooser.errmsg();
+    showError(error.str());
+    return std::nullopt;
+}
+
 void IntegratorGUI::handleLoad() {
-    auto path = promptString("Путь к файлу конфигурации:");
+    auto path = promptFilePath("Выбор файла конфигурации",
+                               "Введите путь к файлу конфигурации:",
+                               Fl_Native_File_Chooser::BROWSE_FILE,
+                               false);
     if (!path) return;
 
     if (integrator_.loadFromFile(*path)) {
@@ -379,7 +418,10 @@ void IntegratorGUI::handleLoad() {
 }
 
 void IntegratorGUI::handleSave() {
-    auto path = promptString("Путь для сохранения конфигурации:");
+    auto path = promptFilePath("Сохранение конфигурации",
+                               "Введите путь для сохранения конфигурации:",
+                               Fl_Native_File_Chooser::BROWSE_SAVE_FILE,
+                               false);
     if (!path) return;
 
     if (integrator_.saveToFile(*path)) {
@@ -392,9 +434,15 @@ void IntegratorGUI::handleSave() {
 }
 
 void IntegratorGUI::handleSaveStructures() {
-    auto hashPath = promptString("Файл для хеш-таблицы (оставьте пустым, чтобы пропустить):");
+    auto hashPath = promptFilePath("Сохранение хеш-таблицы",
+                                   "Файл для хеш-таблицы (оставьте пустым, чтобы пропустить):",
+                                   Fl_Native_File_Chooser::BROWSE_SAVE_FILE,
+                                   true);
     if (!hashPath) return;
-    auto treePath = promptString("Файл для дерева заказов (оставьте пустым, чтобы пропустить):");
+    auto treePath = promptFilePath("Сохранение дерева заказов",
+                                   "Файл для дерева заказов (оставьте пустым, чтобы пропустить):",
+                                   Fl_Native_File_Chooser::BROWSE_SAVE_FILE,
+                                   true);
     if (!treePath) return;
 
     if (integrator_.saveStructures(*hashPath, *treePath)) {

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -1,3 +1,7 @@
+#if defined(_WIN32) && !defined(WIN32)
+#define WIN32
+#endif
+
 #include <FL/Fl.H>
 #include <FL/Fl_Box.H>
 #include <FL/Fl_Button.H>

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -1,0 +1,663 @@
+#include <FL/Fl.H>
+#include <FL/Fl_Box.H>
+#include <FL/Fl_Button.H>
+#include <FL/Fl_Double_Window.H>
+#include <FL/Fl_Group.H>
+#include <FL/Fl_Text_Buffer.H>
+#include <FL/Fl_Text_Display.H>
+#include <FL/fl_ask.H>
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "data_integrator.hpp"
+
+namespace {
+
+class IntegratorGUI {
+public:
+    IntegratorGUI();
+    ~IntegratorGUI();
+
+    void show();
+
+private:
+    DataIntegrator integrator_;
+
+    Fl_Double_Window* window_;
+    Fl_Group*         toolStrip_;
+    Fl_Text_Display*  hashDisplay_;
+    Fl_Text_Display*  treeDisplay_;
+    Fl_Text_Buffer*   hashBuffer_;
+    Fl_Text_Buffer*   treeBuffer_;
+    Fl_Box*           statusBox_;
+
+    void refreshDataViews();
+    void updateStatus(const std::string& message);
+    void showInfo(const std::string& message);
+    void showError(const std::string& message);
+
+    std::optional<std::string> promptNonEmpty(const char* prompt, const std::string& initial = "");
+    std::optional<std::string> promptString(const char* prompt, const std::string& initial = "");
+    std::optional<int>         promptInt(const char* prompt, int initial, int minimum);
+    std::optional<DriverRecord> promptDriver(const DriverRecord* initial = nullptr);
+    std::optional<OrderRecord>  promptOrder(const OrderRecord* initial = nullptr);
+    std::optional<std::size_t>  promptIndexSelection(std::size_t count, const std::string& title);
+
+    void handleLoad();
+    void handleSave();
+    void handleSaveStructures();
+    void handleClear();
+
+    void handleAddDriver();
+    void handleUpdateDriver();
+    void handleRemoveDriver();
+    void handleFindDriver();
+
+    void handleAddOrder();
+    void handleUpdateOrder();
+    void handleRemoveOrder();
+    void handleShowOrders();
+    void handleCheckOrder();
+
+    static void CallbackLoad(Fl_Widget*, void*);
+    static void CallbackSave(Fl_Widget*, void*);
+    static void CallbackSaveStructures(Fl_Widget*, void*);
+    static void CallbackClear(Fl_Widget*, void*);
+    static void CallbackAddDriver(Fl_Widget*, void*);
+    static void CallbackUpdateDriver(Fl_Widget*, void*);
+    static void CallbackRemoveDriver(Fl_Widget*, void*);
+    static void CallbackFindDriver(Fl_Widget*, void*);
+    static void CallbackAddOrder(Fl_Widget*, void*);
+    static void CallbackUpdateOrder(Fl_Widget*, void*);
+    static void CallbackRemoveOrder(Fl_Widget*, void*);
+    static void CallbackShowOrders(Fl_Widget*, void*);
+    static void CallbackCheckOrder(Fl_Widget*, void*);
+};
+
+IntegratorGUI::IntegratorGUI()
+    : integrator_(),
+      window_(nullptr),
+      toolStrip_(nullptr),
+      hashDisplay_(nullptr),
+      treeDisplay_(nullptr),
+      hashBuffer_(nullptr),
+      treeBuffer_(nullptr),
+      statusBox_(nullptr) {
+    const int windowWidth = 1200;
+    const int windowHeight = 800;
+
+    window_ = new Fl_Double_Window(windowWidth, windowHeight, "Интегратор данных");
+    window_->begin();
+
+    const int buttonWidth = 150;
+    const int buttonHeight = 28;
+    const int buttonSpacing = 10;
+    const int toolStripHeight = 130;
+
+    toolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
+    toolStrip_->box(FL_THIN_UP_BOX);
+    toolStrip_->color(fl_rgb_color(245, 245, 245));
+    toolStrip_->begin();
+
+    int buttonX = 10;
+    int buttonY = 10;
+
+    auto placeButton = [&](const char* label, Fl_Callback* cb) {
+        if (buttonX + buttonWidth > windowWidth - 10) {
+            buttonX = 10;
+            buttonY += buttonHeight + buttonSpacing;
+        }
+        Fl_Button* button = new Fl_Button(buttonX, buttonY, buttonWidth, buttonHeight, label);
+        button->callback(cb, this);
+        buttonX += buttonWidth + buttonSpacing;
+        return button;
+    };
+
+    placeButton("Загрузить...", &IntegratorGUI::CallbackLoad);
+    placeButton("Сохранить...", &IntegratorGUI::CallbackSave);
+    placeButton("Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
+    placeButton("Очистить", &IntegratorGUI::CallbackClear);
+
+    placeButton("Добавить водителя", &IntegratorGUI::CallbackAddDriver);
+    placeButton("Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
+    placeButton("Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
+    placeButton("Найти водителя", &IntegratorGUI::CallbackFindDriver);
+
+    placeButton("Добавить заказ", &IntegratorGUI::CallbackAddOrder);
+    placeButton("Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
+    placeButton("Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
+    placeButton("Заказы водителя", &IntegratorGUI::CallbackShowOrders);
+    placeButton("Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+
+    toolStrip_->end();
+
+    statusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    statusBox_->box(FL_THIN_DOWN_BOX);
+    statusBox_->labelfont(FL_HELVETICA_BOLD);
+    statusBox_->labelsize(14);
+    statusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+    statusBox_->copy_label("Готово.");
+
+    const int contentTop = toolStripHeight + 40;
+    const int contentHeight = windowHeight - contentTop - 10;
+    const int contentWidth = windowWidth - 20;
+    const int contentLeft = 10;
+    const int middleSpacing = 10;
+
+    const int leftWidth = (contentWidth - middleSpacing) / 2;
+    const int rightWidth = contentWidth - leftWidth - middleSpacing;
+
+    Fl_Box* hashLabel = new Fl_Box(contentLeft, contentTop, leftWidth, 25, "Хеш-таблица водителей");
+    hashLabel->labelfont(FL_HELVETICA_BOLD);
+    hashLabel->labelsize(14);
+    hashLabel->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+
+    hashDisplay_ = new Fl_Text_Display(contentLeft, contentTop + 25, leftWidth, contentHeight - 25);
+    hashDisplay_->box(FL_DOWN_BOX);
+    hashDisplay_->textfont(FL_COURIER);
+    hashDisplay_->textsize(13);
+    hashDisplay_->wrap_mode(Fl_Text_Display::WRAP_AT_BOUNDS, 0);
+
+    Fl_Box* treeLabel = new Fl_Box(contentLeft + leftWidth + middleSpacing, contentTop, rightWidth, 25, "Дерево заказов (AVL)");
+    treeLabel->labelfont(FL_HELVETICA_BOLD);
+    treeLabel->labelsize(14);
+    treeLabel->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+
+    treeDisplay_ = new Fl_Text_Display(contentLeft + leftWidth + middleSpacing, contentTop + 25, rightWidth, contentHeight - 25);
+    treeDisplay_->box(FL_DOWN_BOX);
+    treeDisplay_->textfont(FL_COURIER);
+    treeDisplay_->textsize(13);
+    treeDisplay_->wrap_mode(Fl_Text_Display::WRAP_AT_BOUNDS, 0);
+
+    hashBuffer_ = new Fl_Text_Buffer();
+    treeBuffer_ = new Fl_Text_Buffer();
+    hashDisplay_->buffer(hashBuffer_);
+    treeDisplay_->buffer(treeBuffer_);
+
+    window_->end();
+    window_->resizable(window_);
+}
+
+IntegratorGUI::~IntegratorGUI() {
+    if (hashDisplay_) {
+        hashDisplay_->buffer(nullptr);
+    }
+    if (treeDisplay_) {
+        treeDisplay_->buffer(nullptr);
+    }
+    delete hashBuffer_;
+    delete treeBuffer_;
+    delete window_;
+}
+
+void IntegratorGUI::show() {
+    if (window_) {
+        window_->show();
+        refreshDataViews();
+    }
+}
+
+void IntegratorGUI::refreshDataViews() {
+    if (!hashBuffer_ || !treeBuffer_ || !statusBox_) return;
+
+    std::ostringstream status;
+    status << "Водителей: " << integrator_.driverCount()
+           << " | Заказов: " << integrator_.orderCount();
+    statusBox_->copy_label(status.str().c_str());
+
+    std::string hashText = integrator_.hashTableAsText();
+    std::string treeText = integrator_.orderTreeAsText();
+
+    if (hashText.empty()) hashText = "<пусто>";
+    if (treeText.empty()) treeText = "<пусто>";
+
+    hashBuffer_->text(hashText.c_str());
+    treeBuffer_->text(treeText.c_str());
+}
+
+void IntegratorGUI::updateStatus(const std::string& message) {
+    if (statusBox_) {
+        statusBox_->copy_label(message.c_str());
+    }
+}
+
+void IntegratorGUI::showInfo(const std::string& message) {
+    fl_message_title("Информация");
+    fl_message("%s", message.c_str());
+}
+
+void IntegratorGUI::showError(const std::string& message) {
+    fl_message_title("Ошибка");
+    fl_alert("%s", message.c_str());
+}
+
+std::optional<std::string> IntegratorGUI::promptNonEmpty(const char* prompt, const std::string& initial) {
+    std::string current = initial;
+    while (true) {
+        const char* value = fl_input("%s", current.c_str(), prompt);
+        if (!value) {
+            return std::nullopt;
+        }
+        std::string result = value;
+        if (result.empty()) {
+            showError("Поле не может быть пустым.");
+            current = result;
+            continue;
+        }
+        return result;
+    }
+}
+
+std::optional<std::string> IntegratorGUI::promptString(const char* prompt, const std::string& initial) {
+    std::string current = initial;
+    const char* value = fl_input("%s", current.c_str(), prompt);
+    if (!value) {
+        return std::nullopt;
+    }
+    return std::string(value);
+}
+
+std::optional<int> IntegratorGUI::promptInt(const char* prompt, int initial, int minimum) {
+    std::string current = std::to_string(initial);
+    while (true) {
+        const char* value = fl_input("%s", current.c_str(), prompt);
+        if (!value) {
+            return std::nullopt;
+        }
+        std::string result = value;
+        if (result.empty()) {
+            showError("Введите число.");
+            current = result;
+            continue;
+        }
+        try {
+            int parsed = std::stoi(result);
+            if (parsed < minimum) {
+                std::ostringstream error;
+                error << "Значение должно быть не меньше " << minimum << ".";
+                showError(error.str());
+                current = result;
+                continue;
+            }
+            return parsed;
+        }
+        catch (...) {
+            showError("Введите корректное целое число.");
+            current = result;
+        }
+    }
+}
+
+std::optional<DriverRecord> IntegratorGUI::promptDriver(const DriverRecord* initial) {
+    std::optional<std::string> license = promptNonEmpty("Номер водительского удостоверения:", initial ? initial->licenseNumber : "");
+    if (!license) return std::nullopt;
+
+    std::optional<std::string> fio = promptNonEmpty("ФИО водителя:", initial ? initial->fio : "");
+    if (!fio) return std::nullopt;
+
+    std::optional<std::string> carBrand = promptNonEmpty("Марка автомобиля:", initial ? initial->carBrand : "");
+    if (!carBrand) return std::nullopt;
+
+    std::optional<int> originalLine = promptInt("Номер строки в исходном файле (-1 если ввод вручную):", initial ? initial->originalLine : -1, -1);
+    if (!originalLine) return std::nullopt;
+
+    DriverRecord record{*license, *fio, *carBrand, *originalLine};
+    return record;
+}
+
+std::optional<OrderRecord> IntegratorGUI::promptOrder(const OrderRecord* initial) {
+    std::optional<std::string> license = promptNonEmpty("Номер водителя (лицензия):", initial ? initial->licenseNumber : "");
+    if (!license) return std::nullopt;
+
+    std::optional<std::string> address = promptNonEmpty("Адрес заказа:", initial ? initial->address : "");
+    if (!address) return std::nullopt;
+
+    std::optional<std::string> cost = promptNonEmpty("Стоимость:", initial ? initial->cost : "");
+    if (!cost) return std::nullopt;
+
+    std::optional<std::string> date = promptNonEmpty("Дата:", initial ? initial->date : "");
+    if (!date) return std::nullopt;
+
+    OrderRecord record{*license, *address, *cost, *date};
+    return record;
+}
+
+std::optional<std::size_t> IntegratorGUI::promptIndexSelection(std::size_t count, const std::string& title) {
+    if (count == 0) {
+        return std::nullopt;
+    }
+
+    std::string current = "1";
+    while (true) {
+        const char* input = fl_input("%s", current.c_str(), title.c_str());
+        if (!input) {
+            return std::nullopt;
+        }
+        std::string value = input;
+        if (value.empty()) {
+            showError("Введите номер записи.");
+            current = value;
+            continue;
+        }
+        try {
+            long parsed = std::stol(value);
+            if (parsed < 1 || parsed > static_cast<long>(count)) {
+                std::ostringstream message;
+                message << "Введите число от 1 до " << count << ".";
+                showError(message.str());
+                current = value;
+                continue;
+            }
+            return static_cast<std::size_t>(parsed - 1);
+        }
+        catch (...) {
+            showError("Введите корректное число.");
+            current = value;
+        }
+    }
+}
+
+void IntegratorGUI::handleLoad() {
+    auto path = promptString("Путь к файлу конфигурации:");
+    if (!path) return;
+
+    if (integrator_.loadFromFile(*path)) {
+        updateStatus("Файл успешно загружен.");
+        refreshDataViews();
+        showInfo("Данные загружены.");
+    }
+    else {
+        showError("Не удалось загрузить файл.");
+    }
+}
+
+void IntegratorGUI::handleSave() {
+    auto path = promptString("Путь для сохранения конфигурации:");
+    if (!path) return;
+
+    if (integrator_.saveToFile(*path)) {
+        updateStatus("Данные сохранены.");
+        showInfo("Файл сохранён.");
+    }
+    else {
+        showError("Не удалось сохранить файл.");
+    }
+}
+
+void IntegratorGUI::handleSaveStructures() {
+    auto hashPath = promptString("Файл для хеш-таблицы (оставьте пустым, чтобы пропустить):");
+    if (!hashPath) return;
+    auto treePath = promptString("Файл для дерева заказов (оставьте пустым, чтобы пропустить):");
+    if (!treePath) return;
+
+    if (integrator_.saveStructures(*hashPath, *treePath)) {
+        updateStatus("Структуры сохранены.");
+        showInfo("Хеш-таблица и дерево сохранены.");
+    }
+    else {
+        showError("Не удалось сохранить структуры.");
+    }
+}
+
+void IntegratorGUI::handleClear() {
+    int choice = fl_choice("Очистить все данные интегратора?", "Отмена", "Очистить", nullptr);
+    if (choice == 1) {
+        integrator_.clear();
+        refreshDataViews();
+        updateStatus("Интегратор очищен.");
+    }
+}
+
+void IntegratorGUI::handleAddDriver() {
+    auto record = promptDriver();
+    if (!record) return;
+
+    if (integrator_.addDriver(*record)) {
+        refreshDataViews();
+        updateStatus("Водитель добавлен.");
+    }
+    else {
+        showError("Не удалось добавить водителя. Возможно, лицензия уже существует или данные некорректны.");
+    }
+}
+
+void IntegratorGUI::handleUpdateDriver() {
+    auto license = promptNonEmpty("Номер водителя для изменения:");
+    if (!license) return;
+
+    auto stored = integrator_.findDriver(*license);
+    if (!stored.has_value()) {
+        showError("Водитель с таким номером не найден.");
+        return;
+    }
+
+    auto updated = promptDriver(&stored.value());
+    if (!updated) return;
+
+    if (updated->licenseNumber != stored->licenseNumber) {
+        showError("Нельзя изменять номер водительского удостоверения.");
+        return;
+    }
+
+    if (integrator_.updateDriver(*stored, *updated)) {
+        refreshDataViews();
+        updateStatus("Данные водителя обновлены.");
+    }
+    else {
+        showError("Не удалось обновить данные водителя.");
+    }
+}
+
+void IntegratorGUI::handleRemoveDriver() {
+    auto license = promptNonEmpty("Номер водителя для удаления:");
+    if (!license) return;
+
+    int choice = fl_choice("Удалить водителя и связанные заказы?", "Отмена", "Удалить", nullptr);
+    if (choice != 1) {
+        return;
+    }
+
+    if (integrator_.removeDriver(*license)) {
+        refreshDataViews();
+        updateStatus("Водитель удалён.");
+    }
+    else {
+        showError("Не удалось удалить водителя.");
+    }
+}
+
+void IntegratorGUI::handleFindDriver() {
+    auto license = promptNonEmpty("Номер водителя для поиска:");
+    if (!license) return;
+
+    auto stored = integrator_.findDriver(*license);
+    if (!stored.has_value()) {
+        showError("Водитель не найден.");
+        return;
+    }
+
+    std::ostringstream info;
+    info << "Лицензия: " << stored->licenseNumber << "\n"
+         << "ФИО: " << stored->fio << "\n"
+         << "Марка: " << stored->carBrand << "\n"
+         << "Исходная строка: " << stored->originalLine;
+    showInfo(info.str());
+}
+
+void IntegratorGUI::handleAddOrder() {
+    auto record = promptOrder();
+    if (!record) return;
+
+    if (integrator_.addOrder(*record)) {
+        refreshDataViews();
+        updateStatus("Заказ добавлен.");
+    }
+    else {
+        showError("Не удалось добавить заказ. Проверьте существование водителя и корректность данных.");
+    }
+}
+
+void IntegratorGUI::handleUpdateOrder() {
+    auto license = promptNonEmpty("Номер водителя для выбора заказа:");
+    if (!license) return;
+
+    std::vector<OrderRecord> orders = integrator_.ordersForDriver(*license);
+    if (orders.empty()) {
+        showError("Для выбранного водителя нет заказов.");
+        return;
+    }
+
+    std::ostringstream list;
+    list << "Заказы водителя " << *license << ":\n\n";
+    for (std::size_t i = 0; i < orders.size(); ++i) {
+        list << (i + 1) << ") " << orders[i].address << " | " << orders[i].cost << " | " << orders[i].date << "\n";
+    }
+    showInfo(list.str());
+
+    auto index = promptIndexSelection(orders.size(), "Номер заказа для изменения:");
+    if (!index) return;
+
+    OrderRecord original = orders[*index];
+    auto updated = promptOrder(&original);
+    if (!updated) return;
+
+    if (integrator_.updateOrder(original, *updated)) {
+        refreshDataViews();
+        updateStatus("Заказ обновлён.");
+    }
+    else {
+        showError("Не удалось обновить заказ. Проверьте данные и существование водителя.");
+    }
+}
+
+void IntegratorGUI::handleRemoveOrder() {
+    auto license = promptNonEmpty("Номер водителя для удаления заказа:");
+    if (!license) return;
+
+    std::vector<OrderRecord> orders = integrator_.ordersForDriver(*license);
+    if (orders.empty()) {
+        showError("Для выбранного водителя нет заказов.");
+        return;
+    }
+
+    std::ostringstream list;
+    list << "Заказы водителя " << *license << ":\n\n";
+    for (std::size_t i = 0; i < orders.size(); ++i) {
+        list << (i + 1) << ") " << orders[i].address << " | " << orders[i].cost << " | " << orders[i].date << "\n";
+    }
+    showInfo(list.str());
+
+    auto index = promptIndexSelection(orders.size(), "Номер заказа для удаления:");
+    if (!index) return;
+
+    OrderRecord target = orders[*index];
+    int choice = fl_choice("Удалить выбранный заказ?", "Отмена", "Удалить", nullptr);
+    if (choice != 1) {
+        return;
+    }
+
+    if (integrator_.removeOrder(target)) {
+        refreshDataViews();
+        updateStatus("Заказ удалён.");
+    }
+    else {
+        showError("Не удалось удалить заказ.");
+    }
+}
+
+void IntegratorGUI::handleShowOrders() {
+    auto license = promptNonEmpty("Номер водителя для отображения заказов:");
+    if (!license) return;
+
+    std::vector<OrderRecord> orders = integrator_.ordersForDriver(*license);
+    if (orders.empty()) {
+        showInfo("У данного водителя нет заказов.");
+        return;
+    }
+
+    std::ostringstream list;
+    list << "Заказы водителя " << *license << ":\n\n";
+    for (const auto& order : orders) {
+        list << "- " << order.address << " | " << order.cost << " | " << order.date << "\n";
+    }
+    showInfo(list.str());
+}
+
+void IntegratorGUI::handleCheckOrder() {
+    auto record = promptOrder();
+    if (!record) return;
+
+    if (integrator_.hasOrder(*record)) {
+        showInfo("Такой заказ найден в системе.");
+    }
+    else {
+        showInfo("Такого заказа нет.");
+    }
+}
+
+void IntegratorGUI::CallbackLoad(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleLoad();
+}
+
+void IntegratorGUI::CallbackSave(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleSave();
+}
+
+void IntegratorGUI::CallbackSaveStructures(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleSaveStructures();
+}
+
+void IntegratorGUI::CallbackClear(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleClear();
+}
+
+void IntegratorGUI::CallbackAddDriver(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleAddDriver();
+}
+
+void IntegratorGUI::CallbackUpdateDriver(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleUpdateDriver();
+}
+
+void IntegratorGUI::CallbackRemoveDriver(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleRemoveDriver();
+}
+
+void IntegratorGUI::CallbackFindDriver(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleFindDriver();
+}
+
+void IntegratorGUI::CallbackAddOrder(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleAddOrder();
+}
+
+void IntegratorGUI::CallbackUpdateOrder(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleUpdateOrder();
+}
+
+void IntegratorGUI::CallbackRemoveOrder(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleRemoveOrder();
+}
+
+void IntegratorGUI::CallbackShowOrders(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleShowOrders();
+}
+
+void IntegratorGUI::CallbackCheckOrder(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleCheckOrder();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    Fl::scheme("plastic");
+    IntegratorGUI gui;
+    gui.show();
+    return Fl::run();
+}
+

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -314,11 +314,14 @@ TEST(DataIntegratorTest, IntegratorDumpsStructuresToText) {
     ASSERT_TRUE(integrator.addOrder(orderD));
 
     auto hashDump = integrator.hashTableAsText();
-    EXPECT_NE(hashDump.find("HashTable dump"), std::string::npos);
-    EXPECT_NE(hashDump.find(alpha.licenseNumber), std::string::npos);
+    EXPECT_NE(hashDump.find("Водителей:"), std::string::npos);
+    EXPECT_NE(hashDump.find("ФИО: Alpha Tester"), std::string::npos);
+    EXPECT_NE(hashDump.find("Заказов: 2"), std::string::npos);
 
     auto treeDump = integrator.orderTreeAsText();
-    EXPECT_NE(treeDump.find(alpha.licenseNumber), std::string::npos);
+    EXPECT_NE(treeDump.find("Всего заказов: 4"), std::string::npos);
+    EXPECT_NE(treeDump.find("Alpha Street"), std::string::npos);
+    EXPECT_NE(treeDump.find("Alpha Avenue"), std::string::npos);
     EXPECT_NE(treeDump.find("|--"), std::string::npos);
 
     auto basePath = TempFilePathForCurrentTest();

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -469,15 +469,16 @@ TEST(DataIntegratorUseCasesTest, UseCase28_ShowDiagnosticsDumps) {
     PrepareDiagnosticsData(integrator);
 
     auto hashDump = integrator.hashTableAsText();
-    EXPECT_NE(hashDump.find("HashTable dump"), std::string::npos);
-    EXPECT_NE(hashDump.find("DL-HASH-1"), std::string::npos);
-    EXPECT_NE(hashDump.find("DL-HASH-2"), std::string::npos);
-    EXPECT_NE(hashDump.find("DL-HASH-3"), std::string::npos);
+    EXPECT_NE(hashDump.find("Водителей: 3"), std::string::npos);
+    EXPECT_NE(hashDump.find("ФИО: Alpha Tester"), std::string::npos);
+    EXPECT_NE(hashDump.find("ФИО: Beta Tester"), std::string::npos);
+    EXPECT_NE(hashDump.find("ФИО: Gamma Tester"), std::string::npos);
 
     auto treeDump = integrator.orderTreeAsText();
-    EXPECT_NE(treeDump.find("|--"), std::string::npos);
+    EXPECT_NE(treeDump.find("Всего заказов: 4"), std::string::npos);
     EXPECT_NE(treeDump.find("DL-HASH-1"), std::string::npos);
-    EXPECT_NE(treeDump.find("[0,3]"), std::string::npos);
+    EXPECT_NE(treeDump.find("Alpha Avenue"), std::string::npos);
+    EXPECT_NE(treeDump.find("|--"), std::string::npos);
 }
 
 TEST(DataIntegratorUseCasesTest, UseCase29_SaveDiagnosticsSeparately) {


### PR DESCRIPTION
## Summary
- add a new FLTK-based desktop GUI that exposes the full DataIntegrator workflow via dialogs and a tool strip
- display the hash table and AVL tree structures within dedicated panes so users can inspect driver and order storage
- update CMake to fetch FLTK automatically and build the GUI executable alongside the existing tests

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d22d28413c83248f1aa450fff34b01