### PR TITLE
Split table views into separate windows

### DIFF
--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -7,6 +7,8 @@
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
 #include <FL/Fl_Button.H>
+#include <FL/Fl_Input.H>
+#include <FL/Fl_Choice.H>
 #include <FL/Fl_Native_File_Chooser.H>
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
@@ -15,11 +17,89 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "data_integrator.hpp"
 
 namespace {
+
+class ToolStrip : public Fl_Group {
+public:
+    ToolStrip(int X, int Y, int W, int H,
+              int padding = 10,
+              int spacing = 8,
+              int itemHeight = 28)
+        : Fl_Group(X, Y, W, H),
+          padding_(padding),
+          spacing_(spacing),
+          itemHeight_(itemHeight),
+          currentX_(padding),
+          currentY_(padding) {
+        box(FL_THIN_UP_BOX);
+        color(fl_rgb_color(245, 245, 245));
+    }
+
+    Fl_Button* addButton(const char* label, Fl_Callback* cb, void* data, int width = 160) {
+        auto [itemX, itemY] = reserveSlot(width, itemHeight_);
+        auto* button = new Fl_Button(itemX, itemY, width, itemHeight_, label);
+        button->callback(cb, data);
+        return button;
+    }
+
+    Fl_Box* addLabel(const char* label, int width = 120) {
+        auto [itemX, itemY] = reserveSlot(width, itemHeight_);
+        auto* box = new Fl_Box(itemX, itemY, width, itemHeight_, label);
+        box->box(FL_FLAT_BOX);
+        box->labelfont(FL_HELVETICA_BOLD);
+        box->labelsize(12);
+        box->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+        return box;
+    }
+
+    Fl_Input* addTextBox(const char* tooltip = nullptr, int width = 160) {
+        auto [itemX, itemY] = reserveSlot(width, itemHeight_);
+        auto* input = new Fl_Input(itemX, itemY, width, itemHeight_);
+        if (tooltip) input->tooltip(tooltip);
+        return input;
+    }
+
+    Fl_Choice* addComboBox(const std::vector<std::string>& items, int width = 160) {
+        auto [itemX, itemY] = reserveSlot(width, itemHeight_);
+        auto* choice = new Fl_Choice(itemX, itemY, width, itemHeight_);
+        for (const auto& item : items) {
+            choice->add(item.c_str());
+        }
+        return choice;
+    }
+
+    Fl_Box* addSeparator(int width = 12) {
+        auto [itemX, itemY] = reserveSlot(width, itemHeight_);
+        auto* separator = new Fl_Box(itemX, itemY, width, itemHeight_);
+        separator->box(FL_THIN_UP_BOX);
+        separator->color(fl_rgb_color(220, 220, 220));
+        separator->deactivate();
+        return separator;
+    }
+
+private:
+    std::pair<int, int> reserveSlot(int width, int height) {
+        if (currentX_ + width > w() - padding_) {
+            currentX_ = padding_;
+            currentY_ += height + spacing_;
+        }
+        int itemX = x() + currentX_;
+        int itemY = y() + currentY_;
+        currentX_ += width + spacing_;
+        return {itemX, itemY};
+    }
+
+    int padding_;
+    int spacing_;
+    int itemHeight_;
+    int currentX_;
+    int currentY_;
+};
 
 class IntegratorGUI {
 public:
@@ -33,8 +113,8 @@ private:
 
     Fl_Double_Window* hashWindow_;
     Fl_Double_Window* treeWindow_;
-    Fl_Group*         hashToolStrip_;
-    Fl_Group*         treeToolStrip_;
+    ToolStrip*        hashToolStrip_;
+    ToolStrip*        treeToolStrip_;
     Fl_Text_Display*  hashDisplay_;
     Fl_Text_Display*  treeDisplay_;
     Fl_Text_Buffer*   hashBuffer_;
@@ -105,41 +185,24 @@ IntegratorGUI::IntegratorGUI()
     const int windowHeight = 700;
 
     const int toolStripHeight = 90;
-    const int toolStripPadding = 10;
-    const int buttonWidth = 160;
-    const int buttonHeight = 28;
-    const int buttonSpacing = 8;
 
     hashWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Водители (хеш-таблица)");
     hashWindow_->begin();
 
-    hashToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    hashToolStrip_->box(FL_THIN_UP_BOX);
-    hashToolStrip_->color(fl_rgb_color(245, 245, 245));
+    hashToolStrip_ = new ToolStrip(0, 0, windowWidth, toolStripHeight);
     hashToolStrip_->begin();
-
-    int hashButtonX = toolStripPadding;
-    int hashButtonY = toolStripPadding;
-
-    auto placeHashButton = [&](const char* label, Fl_Callback* cb) {
-        if (hashButtonX + buttonWidth > windowWidth - toolStripPadding) {
-            hashButtonX = toolStripPadding;
-            hashButtonY += buttonHeight + buttonSpacing;
-        }
-        Fl_Button* button = new Fl_Button(hashButtonX, hashButtonY, buttonWidth, buttonHeight, label);
-        button->callback(cb, this);
-        hashButtonX += buttonWidth + buttonSpacing;
-    };
-
-    placeHashButton("Загрузить...", &IntegratorGUI::CallbackLoad);
-    placeHashButton("Сохранить...", &IntegratorGUI::CallbackSave);
-    placeHashButton("Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
-    placeHashButton("Очистить", &IntegratorGUI::CallbackClear);
-
-    placeHashButton("Добавить водителя", &IntegratorGUI::CallbackAddDriver);
-    placeHashButton("Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
-    placeHashButton("Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
-    placeHashButton("Найти водителя", &IntegratorGUI::CallbackFindDriver);
+    hashToolStrip_->addLabel("Файл", 70);
+    hashToolStrip_->addButton("Загрузить...", &IntegratorGUI::CallbackLoad, this);
+    hashToolStrip_->addButton("Сохранить...", &IntegratorGUI::CallbackSave, this);
+    hashToolStrip_->addButton("Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures, this);
+    hashToolStrip_->addSeparator();
+    hashToolStrip_->addButton("Очистить", &IntegratorGUI::CallbackClear, this);
+    hashToolStrip_->addSeparator();
+    hashToolStrip_->addLabel("Водители", 110);
+    hashToolStrip_->addButton("Добавить водителя", &IntegratorGUI::CallbackAddDriver, this);
+    hashToolStrip_->addButton("Изменить водителя", &IntegratorGUI::CallbackUpdateDriver, this);
+    hashToolStrip_->addButton("Удалить водителя", &IntegratorGUI::CallbackRemoveDriver, this);
+    hashToolStrip_->addButton("Найти водителя", &IntegratorGUI::CallbackFindDriver, this);
 
     hashToolStrip_->end();
 
@@ -170,29 +233,15 @@ IntegratorGUI::IntegratorGUI()
     treeWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Заказы (AVL-дерево)");
     treeWindow_->begin();
 
-    treeToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    treeToolStrip_->box(FL_THIN_UP_BOX);
-    treeToolStrip_->color(fl_rgb_color(245, 245, 245));
+    treeToolStrip_ = new ToolStrip(0, 0, windowWidth, toolStripHeight);
     treeToolStrip_->begin();
-
-    int treeButtonX = toolStripPadding;
-    int treeButtonY = toolStripPadding;
-
-    auto placeTreeButton = [&](const char* label, Fl_Callback* cb) {
-        if (treeButtonX + buttonWidth > windowWidth - toolStripPadding) {
-            treeButtonX = toolStripPadding;
-            treeButtonY += buttonHeight + buttonSpacing;
-        }
-        Fl_Button* button = new Fl_Button(treeButtonX, treeButtonY, buttonWidth, buttonHeight, label);
-        button->callback(cb, this);
-        treeButtonX += buttonWidth + buttonSpacing;
-    };
-
-    placeTreeButton("Добавить заказ", &IntegratorGUI::CallbackAddOrder);
-    placeTreeButton("Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
-    placeTreeButton("Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
-    placeTreeButton("Заказы водителя", &IntegratorGUI::CallbackShowOrders);
-    placeTreeButton("Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+    treeToolStrip_->addLabel("Заказы", 100);
+    treeToolStrip_->addButton("Добавить заказ", &IntegratorGUI::CallbackAddOrder, this);
+    treeToolStrip_->addButton("Изменить заказ", &IntegratorGUI::CallbackUpdateOrder, this);
+    treeToolStrip_->addButton("Удалить заказ", &IntegratorGUI::CallbackRemoveOrder, this);
+    treeToolStrip_->addSeparator();
+    treeToolStrip_->addButton("Заказы водителя", &IntegratorGUI::CallbackShowOrders, this);
+    treeToolStrip_->addButton("Проверить заказ", &IntegratorGUI::CallbackCheckOrder, this);
 
     treeToolStrip_->end();
 

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -31,13 +31,16 @@ public:
 private:
     DataIntegrator integrator_;
 
-    Fl_Double_Window* window_;
-    Fl_Group*         toolStrip_;
+    Fl_Double_Window* hashWindow_;
+    Fl_Double_Window* treeWindow_;
+    Fl_Group*         hashToolStrip_;
+    Fl_Group*         treeToolStrip_;
     Fl_Text_Display*  hashDisplay_;
     Fl_Text_Display*  treeDisplay_;
     Fl_Text_Buffer*   hashBuffer_;
     Fl_Text_Buffer*   treeBuffer_;
-    Fl_Box*           statusBox_;
+    Fl_Box*           hashStatusBox_;
+    Fl_Box*           treeStatusBox_;
 
     void refreshDataViews();
     void updateStatus(const std::string& message);
@@ -88,106 +91,127 @@ private:
 
 IntegratorGUI::IntegratorGUI()
     : integrator_(),
-      window_(nullptr),
-      toolStrip_(nullptr),
+      hashWindow_(nullptr),
+      treeWindow_(nullptr),
+      hashToolStrip_(nullptr),
+      treeToolStrip_(nullptr),
       hashDisplay_(nullptr),
       treeDisplay_(nullptr),
       hashBuffer_(nullptr),
       treeBuffer_(nullptr),
-      statusBox_(nullptr) {
-    const int windowWidth = 1200;
-    const int windowHeight = 800;
+      hashStatusBox_(nullptr),
+      treeStatusBox_(nullptr) {
+    const int windowWidth = 700;
+    const int windowHeight = 700;
 
-    window_ = new Fl_Double_Window(windowWidth, windowHeight, "Интегратор данных");
-    window_->begin();
-
-    const int buttonWidth = 150;
+    const int buttonWidth = 160;
     const int buttonHeight = 28;
     const int buttonSpacing = 10;
-    const int toolStripHeight = 130;
+    const int toolStripHeight = 140;
 
-    toolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    toolStrip_->box(FL_THIN_UP_BOX);
-    toolStrip_->color(fl_rgb_color(245, 245, 245));
-    toolStrip_->begin();
-
-    int buttonX = 10;
-    int buttonY = 10;
-
-    auto placeButton = [&](const char* label, Fl_Callback* cb) {
-        if (buttonX + buttonWidth > windowWidth - 10) {
-            buttonX = 10;
-            buttonY += buttonHeight + buttonSpacing;
+    auto createToolbarButton = [&](Fl_Group* strip, int& x, int& y, const char* label, Fl_Callback* cb) {
+        if (x + buttonWidth > strip->w() - 10) {
+            x = 10;
+            y += buttonHeight + buttonSpacing;
         }
-        Fl_Button* button = new Fl_Button(buttonX, buttonY, buttonWidth, buttonHeight, label);
+        Fl_Button* button = new Fl_Button(strip->x() + x, strip->y() + y, buttonWidth, buttonHeight, label);
         button->callback(cb, this);
-        buttonX += buttonWidth + buttonSpacing;
+        x += buttonWidth + buttonSpacing;
         return button;
     };
 
-    placeButton("Загрузить...", &IntegratorGUI::CallbackLoad);
-    placeButton("Сохранить...", &IntegratorGUI::CallbackSave);
-    placeButton("Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
-    placeButton("Очистить", &IntegratorGUI::CallbackClear);
+    hashWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Водители (хеш-таблица)");
+    hashWindow_->begin();
 
-    placeButton("Добавить водителя", &IntegratorGUI::CallbackAddDriver);
-    placeButton("Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
-    placeButton("Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
-    placeButton("Найти водителя", &IntegratorGUI::CallbackFindDriver);
+    hashToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
+    hashToolStrip_->box(FL_THIN_UP_BOX);
+    hashToolStrip_->color(fl_rgb_color(245, 245, 245));
+    hashToolStrip_->begin();
 
-    placeButton("Добавить заказ", &IntegratorGUI::CallbackAddOrder);
-    placeButton("Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
-    placeButton("Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
-    placeButton("Заказы водителя", &IntegratorGUI::CallbackShowOrders);
-    placeButton("Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+    int hashButtonX = 10;
+    int hashButtonY = 10;
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Загрузить...", &IntegratorGUI::CallbackLoad);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить...", &IntegratorGUI::CallbackSave);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Очистить", &IntegratorGUI::CallbackClear);
 
-    toolStrip_->end();
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Добавить водителя", &IntegratorGUI::CallbackAddDriver);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Найти водителя", &IntegratorGUI::CallbackFindDriver);
 
-    statusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
-    statusBox_->box(FL_THIN_DOWN_BOX);
-    statusBox_->labelfont(FL_HELVETICA_BOLD);
-    statusBox_->labelsize(14);
-    statusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
-    statusBox_->copy_label("Готово.");
+    hashToolStrip_->end();
 
-    const int contentTop = toolStripHeight + 40;
-    const int contentHeight = windowHeight - contentTop - 10;
-    const int contentWidth = windowWidth - 20;
-    const int contentLeft = 10;
-    const int middleSpacing = 10;
+    hashStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    hashStatusBox_->box(FL_THIN_DOWN_BOX);
+    hashStatusBox_->labelfont(FL_HELVETICA_BOLD);
+    hashStatusBox_->labelsize(14);
+    hashStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+    hashStatusBox_->copy_label("Готово.");
 
-    const int leftWidth = (contentWidth - middleSpacing) / 2;
-    const int rightWidth = contentWidth - leftWidth - middleSpacing;
+    const int hashContentTop = toolStripHeight + 40;
+    const int hashContentHeight = windowHeight - hashContentTop - 10;
 
-    Fl_Box* hashLabel = new Fl_Box(contentLeft, contentTop, leftWidth, 25, "Хеш-таблица водителей");
+    Fl_Box* hashLabel = new Fl_Box(10, hashContentTop, windowWidth - 20, 25, "Хеш-таблица водителей");
     hashLabel->labelfont(FL_HELVETICA_BOLD);
     hashLabel->labelsize(14);
     hashLabel->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
 
-    hashDisplay_ = new Fl_Text_Display(contentLeft, contentTop + 25, leftWidth, contentHeight - 25);
+    hashDisplay_ = new Fl_Text_Display(10, hashContentTop + 25, windowWidth - 20, hashContentHeight - 25);
     hashDisplay_->box(FL_DOWN_BOX);
     hashDisplay_->textfont(FL_COURIER);
     hashDisplay_->textsize(13);
     hashDisplay_->wrap_mode(Fl_Text_Display::WRAP_AT_BOUNDS, 0);
 
-    Fl_Box* treeLabel = new Fl_Box(contentLeft + leftWidth + middleSpacing, contentTop, rightWidth, 25, "Дерево заказов (AVL)");
+    hashWindow_->end();
+    hashWindow_->resizable(hashDisplay_);
+
+    treeWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Заказы (AVL-дерево)");
+    treeWindow_->begin();
+
+    treeToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
+    treeToolStrip_->box(FL_THIN_UP_BOX);
+    treeToolStrip_->color(fl_rgb_color(245, 245, 245));
+    treeToolStrip_->begin();
+
+    int treeButtonX = 10;
+    int treeButtonY = 10;
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Добавить заказ", &IntegratorGUI::CallbackAddOrder);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Заказы водителя", &IntegratorGUI::CallbackShowOrders);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+
+    treeToolStrip_->end();
+
+    treeStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    treeStatusBox_->box(FL_THIN_DOWN_BOX);
+    treeStatusBox_->labelfont(FL_HELVETICA_BOLD);
+    treeStatusBox_->labelsize(14);
+    treeStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
+    treeStatusBox_->copy_label("Готово.");
+
+    const int treeContentTop = toolStripHeight + 40;
+    const int treeContentHeight = windowHeight - treeContentTop - 10;
+
+    Fl_Box* treeLabel = new Fl_Box(10, treeContentTop, windowWidth - 20, 25, "Дерево заказов (AVL)");
     treeLabel->labelfont(FL_HELVETICA_BOLD);
     treeLabel->labelsize(14);
     treeLabel->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
 
-    treeDisplay_ = new Fl_Text_Display(contentLeft + leftWidth + middleSpacing, contentTop + 25, rightWidth, contentHeight - 25);
+    treeDisplay_ = new Fl_Text_Display(10, treeContentTop + 25, windowWidth - 20, treeContentHeight - 25);
     treeDisplay_->box(FL_DOWN_BOX);
     treeDisplay_->textfont(FL_COURIER);
     treeDisplay_->textsize(13);
     treeDisplay_->wrap_mode(Fl_Text_Display::WRAP_AT_BOUNDS, 0);
 
+    treeWindow_->end();
+    treeWindow_->resizable(treeDisplay_);
+
     hashBuffer_ = new Fl_Text_Buffer();
     treeBuffer_ = new Fl_Text_Buffer();
     hashDisplay_->buffer(hashBuffer_);
     treeDisplay_->buffer(treeBuffer_);
-
-    window_->end();
-    window_->resizable(window_);
 }
 
 IntegratorGUI::~IntegratorGUI() {
@@ -199,23 +223,24 @@ IntegratorGUI::~IntegratorGUI() {
     }
     delete hashBuffer_;
     delete treeBuffer_;
-    delete window_;
+    delete hashWindow_;
+    delete treeWindow_;
 }
 
 void IntegratorGUI::show() {
-    if (window_) {
-        window_->show();
-        refreshDataViews();
-    }
+    if (hashWindow_) hashWindow_->show();
+    if (treeWindow_) treeWindow_->show();
+    refreshDataViews();
 }
 
 void IntegratorGUI::refreshDataViews() {
-    if (!hashBuffer_ || !treeBuffer_ || !statusBox_) return;
+    if (!hashBuffer_ || !treeBuffer_) return;
 
     std::ostringstream status;
     status << "Водителей: " << integrator_.driverCount()
            << " | Заказов: " << integrator_.orderCount();
-    statusBox_->copy_label(status.str().c_str());
+    if (hashStatusBox_) hashStatusBox_->copy_label(status.str().c_str());
+    if (treeStatusBox_) treeStatusBox_->copy_label(status.str().c_str());
 
     std::string hashText = integrator_.hashTableAsText();
     std::string treeText = integrator_.orderTreeAsText();
@@ -228,9 +253,8 @@ void IntegratorGUI::refreshDataViews() {
 }
 
 void IntegratorGUI::updateStatus(const std::string& message) {
-    if (statusBox_) {
-        statusBox_->copy_label(message.c_str());
-    }
+    if (hashStatusBox_) hashStatusBox_->copy_label(message.c_str());
+    if (treeStatusBox_) treeStatusBox_->copy_label(message.c_str());
 }
 
 void IntegratorGUI::showInfo(const std::string& message) {

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -6,7 +6,7 @@
 #include <FL/Fl_Box.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
-#include <FL/Fl_Menu_Bar.H>
+#include <FL/Fl_Button.H>
 #include <FL/Fl_Native_File_Chooser.H>
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
@@ -33,8 +33,8 @@ private:
 
     Fl_Double_Window* hashWindow_;
     Fl_Double_Window* treeWindow_;
-    Fl_Menu_Bar*      hashMenuBar_;
-    Fl_Menu_Bar*      treeMenuBar_;
+    Fl_Group*         hashToolStrip_;
+    Fl_Group*         treeToolStrip_;
     Fl_Text_Display*  hashDisplay_;
     Fl_Text_Display*  treeDisplay_;
     Fl_Text_Buffer*   hashBuffer_;
@@ -93,8 +93,8 @@ IntegratorGUI::IntegratorGUI()
     : integrator_(),
       hashWindow_(nullptr),
       treeWindow_(nullptr),
-      hashMenuBar_(nullptr),
-      treeMenuBar_(nullptr),
+      hashToolStrip_(nullptr),
+      treeToolStrip_(nullptr),
       hashDisplay_(nullptr),
       treeDisplay_(nullptr),
       hashBuffer_(nullptr),
@@ -104,30 +104,53 @@ IntegratorGUI::IntegratorGUI()
     const int windowWidth = 700;
     const int windowHeight = 700;
 
-    const int menuHeight = 30;
+    const int toolStripHeight = 90;
+    const int toolStripPadding = 10;
+    const int buttonWidth = 160;
+    const int buttonHeight = 28;
+    const int buttonSpacing = 8;
 
     hashWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Водители (хеш-таблица)");
     hashWindow_->begin();
 
-    hashMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuHeight);
-    hashMenuBar_->box(FL_FLAT_BOX);
-    hashMenuBar_->add("Файл/Загрузить...", 0, &IntegratorGUI::CallbackLoad, this);
-    hashMenuBar_->add("Файл/Сохранить...", 0, &IntegratorGUI::CallbackSave, this);
-    hashMenuBar_->add("Файл/Сохранить структуры...", 0, &IntegratorGUI::CallbackSaveStructures, this);
-    hashMenuBar_->add("Файл/Очистить", 0, &IntegratorGUI::CallbackClear, this, FL_MENU_DIVIDER);
-    hashMenuBar_->add("Водители/Добавить", 0, &IntegratorGUI::CallbackAddDriver, this);
-    hashMenuBar_->add("Водители/Изменить", 0, &IntegratorGUI::CallbackUpdateDriver, this);
-    hashMenuBar_->add("Водители/Удалить", 0, &IntegratorGUI::CallbackRemoveDriver, this);
-    hashMenuBar_->add("Водители/Найти", 0, &IntegratorGUI::CallbackFindDriver, this);
+    hashToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
+    hashToolStrip_->box(FL_THIN_UP_BOX);
+    hashToolStrip_->color(fl_rgb_color(245, 245, 245));
+    hashToolStrip_->begin();
 
-    hashStatusBox_ = new Fl_Box(10, menuHeight + 5, windowWidth - 20, 30);
+    int hashButtonX = toolStripPadding;
+    int hashButtonY = toolStripPadding;
+
+    auto placeHashButton = [&](const char* label, Fl_Callback* cb) {
+        if (hashButtonX + buttonWidth > windowWidth - toolStripPadding) {
+            hashButtonX = toolStripPadding;
+            hashButtonY += buttonHeight + buttonSpacing;
+        }
+        Fl_Button* button = new Fl_Button(hashButtonX, hashButtonY, buttonWidth, buttonHeight, label);
+        button->callback(cb, this);
+        hashButtonX += buttonWidth + buttonSpacing;
+    };
+
+    placeHashButton("Загрузить...", &IntegratorGUI::CallbackLoad);
+    placeHashButton("Сохранить...", &IntegratorGUI::CallbackSave);
+    placeHashButton("Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
+    placeHashButton("Очистить", &IntegratorGUI::CallbackClear);
+
+    placeHashButton("Добавить водителя", &IntegratorGUI::CallbackAddDriver);
+    placeHashButton("Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
+    placeHashButton("Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
+    placeHashButton("Найти водителя", &IntegratorGUI::CallbackFindDriver);
+
+    hashToolStrip_->end();
+
+    hashStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
     hashStatusBox_->box(FL_THIN_DOWN_BOX);
     hashStatusBox_->labelfont(FL_HELVETICA_BOLD);
     hashStatusBox_->labelsize(14);
     hashStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     hashStatusBox_->copy_label("Готово.");
 
-    const int hashContentTop = menuHeight + 40;
+    const int hashContentTop = toolStripHeight + 40;
     const int hashContentHeight = windowHeight - hashContentTop - 10;
 
     Fl_Box* hashLabel = new Fl_Box(10, hashContentTop, windowWidth - 20, 25, "Хеш-таблица водителей");
@@ -147,22 +170,40 @@ IntegratorGUI::IntegratorGUI()
     treeWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Заказы (AVL-дерево)");
     treeWindow_->begin();
 
-    treeMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuHeight);
-    treeMenuBar_->box(FL_FLAT_BOX);
-    treeMenuBar_->add("Заказы/Добавить", 0, &IntegratorGUI::CallbackAddOrder, this);
-    treeMenuBar_->add("Заказы/Изменить", 0, &IntegratorGUI::CallbackUpdateOrder, this);
-    treeMenuBar_->add("Заказы/Удалить", 0, &IntegratorGUI::CallbackRemoveOrder, this);
-    treeMenuBar_->add("Заказы/Список водителя", 0, &IntegratorGUI::CallbackShowOrders, this);
-    treeMenuBar_->add("Заказы/Проверить", 0, &IntegratorGUI::CallbackCheckOrder, this);
+    treeToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
+    treeToolStrip_->box(FL_THIN_UP_BOX);
+    treeToolStrip_->color(fl_rgb_color(245, 245, 245));
+    treeToolStrip_->begin();
 
-    treeStatusBox_ = new Fl_Box(10, menuHeight + 5, windowWidth - 20, 30);
+    int treeButtonX = toolStripPadding;
+    int treeButtonY = toolStripPadding;
+
+    auto placeTreeButton = [&](const char* label, Fl_Callback* cb) {
+        if (treeButtonX + buttonWidth > windowWidth - toolStripPadding) {
+            treeButtonX = toolStripPadding;
+            treeButtonY += buttonHeight + buttonSpacing;
+        }
+        Fl_Button* button = new Fl_Button(treeButtonX, treeButtonY, buttonWidth, buttonHeight, label);
+        button->callback(cb, this);
+        treeButtonX += buttonWidth + buttonSpacing;
+    };
+
+    placeTreeButton("Добавить заказ", &IntegratorGUI::CallbackAddOrder);
+    placeTreeButton("Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
+    placeTreeButton("Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
+    placeTreeButton("Заказы водителя", &IntegratorGUI::CallbackShowOrders);
+    placeTreeButton("Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+
+    treeToolStrip_->end();
+
+    treeStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
     treeStatusBox_->box(FL_THIN_DOWN_BOX);
     treeStatusBox_->labelfont(FL_HELVETICA_BOLD);
     treeStatusBox_->labelsize(14);
     treeStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     treeStatusBox_->copy_label("Готово.");
 
-    const int treeContentTop = menuHeight + 40;
+    const int treeContentTop = toolStripHeight + 40;
     const int treeContentHeight = windowHeight - treeContentTop - 10;
 
     Fl_Box* treeLabel = new Fl_Box(10, treeContentTop, windowWidth - 20, 25, "Дерево заказов (AVL)");

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -4,9 +4,9 @@
 
 #include <FL/Fl.H>
 #include <FL/Fl_Box.H>
-#include <FL/Fl_Button.H>
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
+#include <FL/Fl_Menu_Bar.H>
 #include <FL/Fl_Native_File_Chooser.H>
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
@@ -33,8 +33,8 @@ private:
 
     Fl_Double_Window* hashWindow_;
     Fl_Double_Window* treeWindow_;
-    Fl_Group*         hashToolStrip_;
-    Fl_Group*         treeToolStrip_;
+    Fl_Menu_Bar*      hashMenuBar_;
+    Fl_Menu_Bar*      treeMenuBar_;
     Fl_Text_Display*  hashDisplay_;
     Fl_Text_Display*  treeDisplay_;
     Fl_Text_Buffer*   hashBuffer_;
@@ -93,8 +93,8 @@ IntegratorGUI::IntegratorGUI()
     : integrator_(),
       hashWindow_(nullptr),
       treeWindow_(nullptr),
-      hashToolStrip_(nullptr),
-      treeToolStrip_(nullptr),
+      hashMenuBar_(nullptr),
+      treeMenuBar_(nullptr),
       hashDisplay_(nullptr),
       treeDisplay_(nullptr),
       hashBuffer_(nullptr),
@@ -104,52 +104,30 @@ IntegratorGUI::IntegratorGUI()
     const int windowWidth = 700;
     const int windowHeight = 700;
 
-    const int buttonWidth = 160;
-    const int buttonHeight = 28;
-    const int buttonSpacing = 10;
-    const int toolStripHeight = 140;
-
-    auto createToolbarButton = [&](Fl_Group* strip, int& x, int& y, const char* label, Fl_Callback* cb) {
-        if (x + buttonWidth > strip->w() - 10) {
-            x = 10;
-            y += buttonHeight + buttonSpacing;
-        }
-        Fl_Button* button = new Fl_Button(strip->x() + x, strip->y() + y, buttonWidth, buttonHeight, label);
-        button->callback(cb, this);
-        x += buttonWidth + buttonSpacing;
-        return button;
-    };
+    const int menuHeight = 30;
 
     hashWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Водители (хеш-таблица)");
     hashWindow_->begin();
 
-    hashToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    hashToolStrip_->box(FL_THIN_UP_BOX);
-    hashToolStrip_->color(fl_rgb_color(245, 245, 245));
-    hashToolStrip_->begin();
+    hashMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuHeight);
+    hashMenuBar_->box(FL_FLAT_BOX);
+    hashMenuBar_->add("Файл/Загрузить...", 0, &IntegratorGUI::CallbackLoad, this);
+    hashMenuBar_->add("Файл/Сохранить...", 0, &IntegratorGUI::CallbackSave, this);
+    hashMenuBar_->add("Файл/Сохранить структуры...", 0, &IntegratorGUI::CallbackSaveStructures, this);
+    hashMenuBar_->add("Файл/Очистить", 0, &IntegratorGUI::CallbackClear, this, FL_MENU_DIVIDER);
+    hashMenuBar_->add("Водители/Добавить", 0, &IntegratorGUI::CallbackAddDriver, this);
+    hashMenuBar_->add("Водители/Изменить", 0, &IntegratorGUI::CallbackUpdateDriver, this);
+    hashMenuBar_->add("Водители/Удалить", 0, &IntegratorGUI::CallbackRemoveDriver, this);
+    hashMenuBar_->add("Водители/Найти", 0, &IntegratorGUI::CallbackFindDriver, this);
 
-    int hashButtonX = 10;
-    int hashButtonY = 10;
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Загрузить...", &IntegratorGUI::CallbackLoad);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить...", &IntegratorGUI::CallbackSave);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Очистить", &IntegratorGUI::CallbackClear);
-
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Добавить водителя", &IntegratorGUI::CallbackAddDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Найти водителя", &IntegratorGUI::CallbackFindDriver);
-
-    hashToolStrip_->end();
-
-    hashStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    hashStatusBox_ = new Fl_Box(10, menuHeight + 5, windowWidth - 20, 30);
     hashStatusBox_->box(FL_THIN_DOWN_BOX);
     hashStatusBox_->labelfont(FL_HELVETICA_BOLD);
     hashStatusBox_->labelsize(14);
     hashStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     hashStatusBox_->copy_label("Готово.");
 
-    const int hashContentTop = toolStripHeight + 40;
+    const int hashContentTop = menuHeight + 40;
     const int hashContentHeight = windowHeight - hashContentTop - 10;
 
     Fl_Box* hashLabel = new Fl_Box(10, hashContentTop, windowWidth - 20, 25, "Хеш-таблица водителей");
@@ -169,29 +147,22 @@ IntegratorGUI::IntegratorGUI()
     treeWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Заказы (AVL-дерево)");
     treeWindow_->begin();
 
-    treeToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    treeToolStrip_->box(FL_THIN_UP_BOX);
-    treeToolStrip_->color(fl_rgb_color(245, 245, 245));
-    treeToolStrip_->begin();
+    treeMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuHeight);
+    treeMenuBar_->box(FL_FLAT_BOX);
+    treeMenuBar_->add("Заказы/Добавить", 0, &IntegratorGUI::CallbackAddOrder, this);
+    treeMenuBar_->add("Заказы/Изменить", 0, &IntegratorGUI::CallbackUpdateOrder, this);
+    treeMenuBar_->add("Заказы/Удалить", 0, &IntegratorGUI::CallbackRemoveOrder, this);
+    treeMenuBar_->add("Заказы/Список водителя", 0, &IntegratorGUI::CallbackShowOrders, this);
+    treeMenuBar_->add("Заказы/Проверить", 0, &IntegratorGUI::CallbackCheckOrder, this);
 
-    int treeButtonX = 10;
-    int treeButtonY = 10;
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Добавить заказ", &IntegratorGUI::CallbackAddOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Заказы водителя", &IntegratorGUI::CallbackShowOrders);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
-
-    treeToolStrip_->end();
-
-    treeStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    treeStatusBox_ = new Fl_Box(10, menuHeight + 5, windowWidth - 20, 30);
     treeStatusBox_->box(FL_THIN_DOWN_BOX);
     treeStatusBox_->labelfont(FL_HELVETICA_BOLD);
     treeStatusBox_->labelsize(14);
     treeStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     treeStatusBox_->copy_label("Готово.");
 
-    const int treeContentTop = toolStripHeight + 40;
+    const int treeContentTop = menuHeight + 40;
     const int treeContentHeight = windowHeight - treeContentTop - 10;
 
     Fl_Box* treeLabel = new Fl_Box(10, treeContentTop, windowWidth - 20, 25, "Дерево заказов (AVL)");


### PR DESCRIPTION
## Summary
- separate the combined data view into dedicated windows for the driver hash table and order AVL tree
- add per-window toolbars and status boxes so each structure has its own controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db6910e03883248098e2457ef45f49