### PR TITLE
Add GUI controls for data structure lifecycle and reporting

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1,11 +1,14 @@
 ﻿#include "data_integrator.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
 #include <vector>
+#include <iomanip>
 
 namespace {
 
@@ -128,17 +131,119 @@ void appendOrderNodeDetailed(const AVLNode*                     node,
     }
 }
 
+std::string normalizeDateKey(const std::string& value) {
+    if (value.empty()) {
+        return {};
+    }
+
+    std::tm parsed{};
+    std::istringstream iso(value);
+    iso >> std::get_time(&parsed, "%Y-%m-%d");
+    if (!iso.fail()) {
+        char buffer[32];
+        std::snprintf(buffer,
+                      sizeof(buffer),
+                      "%04d%02d%02d",
+                      parsed.tm_year + 1900,
+                      parsed.tm_mon + 1,
+                      parsed.tm_mday);
+        return std::string(buffer);
+    }
+
+    std::string digits;
+    digits.reserve(value.size());
+    for (char ch : value) {
+        if (std::isdigit(static_cast<unsigned char>(ch))) {
+            digits.push_back(ch);
+        }
+    }
+    if (digits.size() >= 8) {
+        if (digits.size() > 8) {
+            digits = digits.substr(digits.size() - 8);
+        }
+        return digits;
+    }
+    return value;
+}
+
+bool isDateWithinRange(const std::string& value,
+                       const std::string& from,
+                       const std::string& to) {
+    if (from.empty() && to.empty()) {
+        return true;
+    }
+
+    std::string valueKey = normalizeDateKey(value);
+    std::string fromKey = normalizeDateKey(from);
+    std::string toKey = normalizeDateKey(to);
+
+    if (!from.empty()) {
+        if (fromKey.empty()) {
+            if (value < from) return false;
+        }
+        else {
+            if (valueKey < fromKey) return false;
+        }
+    }
+
+    if (!to.empty()) {
+        if (toKey.empty()) {
+            if (value > to) return false;
+        }
+        else {
+            if (valueKey > toKey) return false;
+        }
+    }
+
+    return true;
+}
+
 } // namespace
 
 DataIntegrator::DataIntegrator(std::size_t driverTableInitialSize, double maxLoadFactor)
     : drivers_(),
       orders_(),
-      driverTable_(driverTableInitialSize, maxLoadFactor),
-      orderTree_{} {
+      driverTable_(std::max<std::size_t>(1u, driverTableInitialSize), maxLoadFactor),
+      orderTree_{},
+      driverTableReady_(false),
+      orderTreeReady_(false),
+      defaultDriverTableSize_(std::max<std::size_t>(1u, driverTableInitialSize)),
+      driverTableMaxLoadFactor_(maxLoadFactor) {
     avl_init(&orderTree_);
 }
 
+bool DataIntegrator::createDriverTable(std::size_t initialSize) {
+    std::size_t size = std::max<std::size_t>(1u, initialSize);
+    driverTable_ = HashTable(size, driverTableMaxLoadFactor_);
+    defaultDriverTableSize_ = size;
+    drivers_.clear();
+    driverTableReady_ = true;
+    return true;
+}
+
+bool DataIntegrator::createOrderTree() {
+    avl_free(&orderTree_);
+    avl_init(&orderTree_);
+    orders_.clear();
+    orderTreeReady_ = true;
+    return true;
+}
+
+void DataIntegrator::clearDriverTable() {
+    drivers_.clear();
+    driverTable_ = HashTable(defaultDriverTableSize_, driverTableMaxLoadFactor_);
+    driverTableReady_ = false;
+}
+
+void DataIntegrator::clearOrderTree() {
+    orders_.clear();
+    avl_free(&orderTree_);
+    avl_init(&orderTree_);
+    orderTreeReady_ = false;
+}
+
 bool DataIntegrator::addDriver(const DriverRecord& record) {
+    if (!driverTableReady_) return false;
     if (!validateDriverRecord(record)) return false;
     if (driverTable_.contains(record.licenseNumber)) return false;
 
@@ -152,17 +257,20 @@ bool DataIntegrator::addDriver(const DriverRecord& record) {
 }
 
 bool DataIntegrator::removeDriver(const DriverRecord& record) {
+    if (!driverTableReady_) return false;
     std::optional<std::size_t> driverIdxOpt = findDriverIndex(record);
     if (!driverIdxOpt.has_value()) return false;
     std::size_t driverIdx = driverIdxOpt.value();
     std::string licenseNumber = record.licenseNumber;
 
-    for (std::size_t i = orders_.size(); i > 0; --i) {
+    if (orderTreeReady_) {
+        for (std::size_t i = orders_.size(); i > 0; --i) {
         std::size_t orderIdx = i - 1;
         OrderRecord order = orders_.at(orderIdx);
         if (order.licenseNumber == licenseNumber) {
             removeOrderByIndex(order.licenseNumber, orderIdx);
         }
+    }
     }
 
     DoublyLinkedList<DriverRecord>::SwapRemoveResult result;
@@ -185,6 +293,7 @@ bool DataIntegrator::removeDriver(const std::string& licenseNumber) {
 }
 
 bool DataIntegrator::updateDriver(const DriverRecord& current, const DriverRecord& updated) {
+    if (!driverTableReady_) return false;
     if (!validateDriverRecord(updated)) return false;
     if (current.licenseNumber != updated.licenseNumber) return false;
 
@@ -204,22 +313,26 @@ bool DataIntegrator::updateDriver(const std::string& licenseNumber, const Driver
 
 
 bool DataIntegrator::hasDriver(const std::string& licenseNumber) const {
+    if (!driverTableReady_) return false;
     return driverTable_.contains(licenseNumber);
 }
 
 std::optional<DriverRecord> DataIntegrator::findDriver(const DriverRecord& record) const {
+    if (!driverTableReady_) return std::nullopt;
     std::optional<std::size_t> driverIdxOpt = findDriverIndex(record);
     if (!driverIdxOpt.has_value()) return std::nullopt;
     return drivers_.at(driverIdxOpt.value());
 }
 
 std::optional<DriverRecord> DataIntegrator::findDriver(const std::string& licenseNumber) const {
+    if (!driverTableReady_) return std::nullopt;
     std::optional<std::size_t> driverIdxOpt = findDriverIndex(licenseNumber);
     if (!driverIdxOpt.has_value()) return std::nullopt;
     return drivers_.at(driverIdxOpt.value());
 }
 
 bool DataIntegrator::addOrder(const OrderRecord& record) {
+    if (!driverTableReady_ || !orderTreeReady_) return false;
     if (!validateOrderRecord(record)) return false;
     if (!driverTable_.contains(record.licenseNumber)) return false;
 
@@ -229,6 +342,7 @@ bool DataIntegrator::addOrder(const OrderRecord& record) {
 }
 
 bool DataIntegrator::removeOrder(const OrderRecord& record) {
+    if (!orderTreeReady_) return false;
     std::optional<std::size_t> idxOpt = findOrderIndex(record, &record);
     if (!idxOpt.has_value()) return false;
     removeOrderByIndex(record.licenseNumber, idxOpt.value());
@@ -236,6 +350,7 @@ bool DataIntegrator::removeOrder(const OrderRecord& record) {
 }
 
 bool DataIntegrator::updateOrder(const OrderRecord& current, const OrderRecord& updated) {
+    if (!orderTreeReady_ || !driverTableReady_) return false;
     std::optional<std::size_t> idxOpt = findOrderIndex(current, &current);
     if (!idxOpt.has_value()) return false;
 
@@ -255,11 +370,13 @@ bool DataIntegrator::updateOrder(const OrderRecord& current, const OrderRecord& 
 }
 
 bool DataIntegrator::hasOrder(const OrderRecord& record) const {
+    if (!orderTreeReady_) return false;
     std::optional<std::size_t> idxOpt = findOrderIndex(record, &record);
     return idxOpt.has_value();
 }
 
 std::vector<OrderRecord> DataIntegrator::ordersForDriver(const std::string& licenseNumber) const {
+    if (!orderTreeReady_) return {};
     std::vector<OrderRecord> result;
     orders_.for_each([&](const OrderRecord& order, std::size_t) {
         if (order.licenseNumber == licenseNumber) {
@@ -270,11 +387,8 @@ std::vector<OrderRecord> DataIntegrator::ordersForDriver(const std::string& lice
 }
 
 void DataIntegrator::clear() {
-    drivers_.clear();
-    orders_.clear();
-    driverTable_.clear();
-    avl_free(&orderTree_);
-    avl_init(&orderTree_);
+    clearDriverTable();
+    clearOrderTree();
 }
 
 bool DataIntegrator::loadFromFile(const std::string& path) {
@@ -312,7 +426,9 @@ bool DataIntegrator::loadFromFile(const std::string& path) {
         parsedOrders.push_back(record);
     }
 
-    DataIntegrator temp(driverTable_.capacity());
+    DataIntegrator temp(driverTable_.capacity(), driverTableMaxLoadFactor_);
+    temp.createDriverTable(driverTable_.capacity());
+    temp.createOrderTree();
 
     bool driversLoaded = true;
     parsedDrivers.for_each([&temp, &driversLoaded](const DriverRecord& driver, std::size_t) {
@@ -345,7 +461,12 @@ bool DataIntegrator::loadFromFile(const std::string& path) {
     orders_ = std::move(temp.orders_);
     driverTable_ = std::move(temp.driverTable_);
     orderTree_ = temp.orderTree_;
+    driverTableReady_ = temp.driverTableReady_;
+    orderTreeReady_ = temp.orderTreeReady_;
+    defaultDriverTableSize_ = temp.defaultDriverTableSize_;
+    driverTableMaxLoadFactor_ = temp.driverTableMaxLoadFactor_;
     temp.orderTree_.root = nullptr;
+    temp.orderTreeReady_ = false;
     return true;
 }
 
@@ -368,6 +489,9 @@ bool DataIntegrator::saveToFile(const std::string& path) const {
 }
 
 std::string DataIntegrator::hashTableAsText() const {
+    if (!driverTableReady_) {
+        return {};
+    }
     std::ostringstream out;
     out << "Водителей: " << drivers_.size()
         << " | Вместимость таблицы: " << driverTable_.capacity()
@@ -403,6 +527,9 @@ std::string DataIntegrator::hashTableAsText() const {
 }
 
 std::string DataIntegrator::orderTreeAsText() const {
+    if (!orderTreeReady_) {
+        return {};
+    }
     if (!orderTree_.root) {
         std::ostringstream empty;
         empty << "Заказов нет\n";
@@ -422,7 +549,13 @@ bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std:
         if (!hashOut.is_open()) {
             return false;
         }
-        hashOut << hashTableAsText();
+        std::string hashText = hashTableAsText();
+        if (hashText.empty()) {
+            hashOut << "Структура хеш-таблицы не создана\n";
+        }
+        else {
+            hashOut << hashText;
+        }
         if (!hashOut) {
             return false;
         }
@@ -433,7 +566,13 @@ bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std:
         if (!treeOut.is_open()) {
             return false;
         }
-        treeOut << orderTreeAsText();
+        std::string treeText = orderTreeAsText();
+        if (treeText.empty()) {
+            treeOut << "Структура дерева заказов не создана\n";
+        }
+        else {
+            treeOut << treeText;
+        }
         if (!treeOut) {
             return false;
         }
@@ -443,6 +582,7 @@ bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std:
 }
 
 std::optional<std::size_t> DataIntegrator::findDriverIndex(const std::string& licenseNumber) const {
+    if (!driverTableReady_) return std::nullopt;
     std::size_t index = 0;
     int steps = 0;
     if (!driverTable_.search(licenseNumber, index, steps)) return std::nullopt;
@@ -460,6 +600,7 @@ std::optional<std::size_t> DataIntegrator::findDriverIndex(const DriverRecord& r
 }
 
 std::optional<std::size_t> DataIntegrator::findOrderIndex(const OrderRecord& key, const OrderRecord* match) const {
+    if (!orderTreeReady_) return std::nullopt;
     const AVLNode* node = avl_search(&orderTree_, key.licenseNumber);
     if (!node) return std::nullopt;
     if (!match) {
@@ -483,6 +624,7 @@ std::optional<std::size_t> DataIntegrator::findOrderIndex(const OrderRecord& key
 }
 
 void DataIntegrator::removeOrderByIndex(const std::string& licenseNumber, std::size_t index) {
+    if (!orderTreeReady_) return;
     DoublyLinkedList<OrderRecord>::SwapRemoveResult result;
     if (!orders_.remove_by_index(index, result)) return;
 
@@ -508,6 +650,66 @@ bool DataIntegrator::validateOrderRecord(const OrderRecord& record) const {
     if (record.cost.empty()) return false;
     if (record.date.empty()) return false;
     return true;
+}
+
+std::vector<ReportEntry> DataIntegrator::generateReport(const std::string& licenseNumber,
+                                                        const std::string& carBrand,
+                                                        const std::string& address,
+                                                        const std::string& dateFrom,
+                                                        const std::string& dateTo) const {
+    std::vector<ReportEntry> result;
+    if (!driverTableReady_ || !orderTreeReady_) {
+        return result;
+    }
+    if (licenseNumber.empty() || carBrand.empty() || address.empty()) {
+        return result;
+    }
+
+    std::optional<DriverRecord> driverOpt = findDriver(licenseNumber);
+    if (!driverOpt.has_value()) {
+        return result;
+    }
+    const DriverRecord& driver = driverOpt.value();
+    if (driver.carBrand != carBrand) {
+        return result;
+    }
+
+    auto driverOrders = ordersForDriver(licenseNumber);
+    for (const OrderRecord& order : driverOrders) {
+        if (order.address != address) {
+            continue;
+        }
+        if (!isDateWithinRange(order.date, dateFrom, dateTo)) {
+            continue;
+        }
+        result.push_back(ReportEntry{driver.licenseNumber,
+                                     driver.fio,
+                                     driver.carBrand,
+                                     order.address,
+                                     order.cost,
+                                     order.date});
+    }
+
+    return result;
+}
+
+std::string DataIntegrator::formatReport(const std::vector<ReportEntry>& entries) const {
+    if (entries.empty()) {
+        return "Совпадений не найдено.\n";
+    }
+
+    std::ostringstream out;
+    out << "Номер лицензии | ФИО | Марка автомобиля | Адрес | Цена | Дата\n";
+    out << "--------------------------------------------------------------------------\n";
+    for (const ReportEntry& entry : entries) {
+        out << entry.licenseNumber << " | "
+            << entry.fio << " | "
+            << entry.carBrand << " | "
+            << entry.address << " | "
+            << entry.cost << " | "
+            << entry.date << '\n';
+    }
+    return out.str();
 }
 
 

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -10,9 +10,25 @@
 #include "hashtable.hpp"
 #include "order_record.hpp"
 
+struct ReportEntry {
+    std::string licenseNumber;
+    std::string fio;
+    std::string carBrand;
+    std::string address;
+    std::string cost;
+    std::string date;
+};
+
 class DataIntegrator {
 public:
     explicit DataIntegrator(std::size_t driverTableInitialSize = 32, double maxLoadFactor = 0.75);
+
+    bool createDriverTable(std::size_t initialSize);
+    bool createOrderTree();
+    void clearDriverTable();
+    void clearOrderTree();
+    bool hasDriverTable() const { return driverTableReady_; }
+    bool hasOrderTree() const { return orderTreeReady_; }
 
     bool addDriver(const DriverRecord& record);
     bool removeDriver(const DriverRecord& record);
@@ -31,6 +47,7 @@ public:
 
     std::size_t driverCount() const { return drivers_.size(); }
     std::size_t orderCount() const { return orders_.size(); }
+    std::size_t driverTableCapacity() const { return driverTable_.capacity(); }
 
     void clear();
 
@@ -40,11 +57,22 @@ public:
     std::string orderTreeAsText() const;
     bool saveStructures(const std::string& hashTablePath, const std::string& treePath) const;
 
+    std::vector<ReportEntry> generateReport(const std::string& licenseNumber,
+                                            const std::string& carBrand,
+                                            const std::string& address,
+                                            const std::string& dateFrom,
+                                            const std::string& dateTo) const;
+    std::string formatReport(const std::vector<ReportEntry>& entries) const;
+
 private:
     DoublyLinkedList<DriverRecord> drivers_;
     DoublyLinkedList<OrderRecord>  orders_;
     HashTable                      driverTable_;
     AVLTree                        orderTree_;
+    bool                           driverTableReady_;
+    bool                           orderTreeReady_;
+    std::size_t                    defaultDriverTableSize_;
+    double                         driverTableMaxLoadFactor_;
 
     std::optional<std::size_t> findDriverIndex(const std::string& licenseNumber) const;
     std::optional<std::size_t> findDriverIndex(const DriverRecord& record) const;

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -46,6 +46,7 @@ private:
     void updateStatus(const std::string& message);
     void showInfo(const std::string& message);
     void showError(const std::string& message);
+    void showTextWindow(const std::string& title, const std::string& content);
 
     std::optional<std::string> promptNonEmpty(const char* prompt, const std::string& initial = "");
     std::optional<std::string> promptString(const char* prompt, const std::string& initial = "");
@@ -62,6 +63,9 @@ private:
     void handleSave();
     void handleSaveStructures();
     void handleClear();
+    void handleCreateDriverTable();
+    void handleClearDriverTableOnly();
+    void handleShowDriverTable();
 
     void handleAddDriver();
     void handleUpdateDriver();
@@ -73,11 +77,18 @@ private:
     void handleRemoveOrder();
     void handleShowOrders();
     void handleCheckOrder();
+    void handleCreateOrderTree();
+    void handleClearOrderTreeOnly();
+    void handleShowOrderTree();
+    void handleGenerateReport();
 
     static void CallbackLoad(Fl_Widget*, void*);
     static void CallbackSave(Fl_Widget*, void*);
     static void CallbackSaveStructures(Fl_Widget*, void*);
     static void CallbackClear(Fl_Widget*, void*);
+    static void CallbackCreateDriverTable(Fl_Widget*, void*);
+    static void CallbackClearDriverTableOnly(Fl_Widget*, void*);
+    static void CallbackShowDriverTable(Fl_Widget*, void*);
     static void CallbackAddDriver(Fl_Widget*, void*);
     static void CallbackUpdateDriver(Fl_Widget*, void*);
     static void CallbackRemoveDriver(Fl_Widget*, void*);
@@ -87,6 +98,10 @@ private:
     static void CallbackRemoveOrder(Fl_Widget*, void*);
     static void CallbackShowOrders(Fl_Widget*, void*);
     static void CallbackCheckOrder(Fl_Widget*, void*);
+    static void CallbackCreateOrderTree(Fl_Widget*, void*);
+    static void CallbackClearOrderTreeOnly(Fl_Widget*, void*);
+    static void CallbackShowOrderTree(Fl_Widget*, void*);
+    static void CallbackGenerateReport(Fl_Widget*, void*);
 };
 
 IntegratorGUI::IntegratorGUI()
@@ -134,6 +149,9 @@ IntegratorGUI::IntegratorGUI()
     createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить...", &IntegratorGUI::CallbackSave);
     createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
     createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Очистить", &IntegratorGUI::CallbackClear);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Создать таблицу", &IntegratorGUI::CallbackCreateDriverTable);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Удалить таблицу", &IntegratorGUI::CallbackClearDriverTableOnly);
+    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Показать таблицу", &IntegratorGUI::CallbackShowDriverTable);
 
     createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Добавить водителя", &IntegratorGUI::CallbackAddDriver);
     createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
@@ -181,6 +199,10 @@ IntegratorGUI::IntegratorGUI()
     createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
     createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Заказы водителя", &IntegratorGUI::CallbackShowOrders);
     createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Создать дерево", &IntegratorGUI::CallbackCreateOrderTree);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить дерево", &IntegratorGUI::CallbackClearOrderTreeOnly);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Показать дерево", &IntegratorGUI::CallbackShowOrderTree);
+    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Сформировать отчёт", &IntegratorGUI::CallbackGenerateReport);
 
     treeToolStrip_->end();
 
@@ -242,11 +264,23 @@ void IntegratorGUI::refreshDataViews() {
     if (hashStatusBox_) hashStatusBox_->copy_label(status.str().c_str());
     if (treeStatusBox_) treeStatusBox_->copy_label(status.str().c_str());
 
-    std::string hashText = integrator_.hashTableAsText();
-    std::string treeText = integrator_.orderTreeAsText();
+    std::string hashText;
+    if (!integrator_.hasDriverTable()) {
+        hashText = "Нет таблицы Водителей";
+    }
+    else {
+        hashText = integrator_.hashTableAsText();
+        if (hashText.empty()) hashText = "<пусто>";
+    }
 
-    if (hashText.empty()) hashText = "<пусто>";
-    if (treeText.empty()) treeText = "<пусто>";
+    std::string treeText;
+    if (!integrator_.hasOrderTree()) {
+        treeText = "Нет таблицы Заказов";
+    }
+    else {
+        treeText = integrator_.orderTreeAsText();
+        if (treeText.empty()) treeText = "<пусто>";
+    }
 
     hashBuffer_->text(hashText.c_str());
     treeBuffer_->text(treeText.c_str());
@@ -265,6 +299,38 @@ void IntegratorGUI::showInfo(const std::string& message) {
 void IntegratorGUI::showError(const std::string& message) {
     fl_message_title("Ошибка");
     fl_alert("%s", message.c_str());
+}
+
+void IntegratorGUI::showTextWindow(const std::string& title, const std::string& content) {
+    Fl_Double_Window* window = new Fl_Double_Window(640, 480, title.c_str());
+    window->begin();
+    Fl_Text_Display* display = new Fl_Text_Display(10, 10, 620, 430);
+    display->box(FL_DOWN_BOX);
+    display->textfont(FL_COURIER);
+    display->textsize(13);
+    Fl_Text_Buffer* buffer = new Fl_Text_Buffer();
+    buffer->text(content.c_str());
+    display->buffer(buffer);
+    window->resizable(display);
+    window->end();
+    struct TextWindowContext {
+        Fl_Text_Display* display;
+        Fl_Text_Buffer*  buffer;
+    };
+    auto* context = new TextWindowContext{display, buffer};
+    window->callback([](Fl_Widget* widget, void* data) {
+        auto* ctx = static_cast<TextWindowContext*>(data);
+        if (ctx) {
+            if (ctx->display) {
+                ctx->display->buffer(nullptr);
+            }
+            delete ctx->buffer;
+            delete ctx;
+        }
+        delete widget;
+    }, context);
+    window->set_non_modal();
+    window->show();
 }
 
 std::optional<std::string> IntegratorGUI::promptNonEmpty(const char* prompt, const std::string& initial) {
@@ -487,7 +553,50 @@ void IntegratorGUI::handleClear() {
     }
 }
 
+void IntegratorGUI::handleCreateDriverTable() {
+    int defaultSize = static_cast<int>(integrator_.driverTableCapacity());
+    auto sizeOpt = promptInt("Начальный размер хеш-таблицы:", defaultSize, 1);
+    if (!sizeOpt) return;
+
+    if (integrator_.createDriverTable(static_cast<std::size_t>(*sizeOpt))) {
+        refreshDataViews();
+        updateStatus("Хеш-таблица создана.");
+    }
+    else {
+        showError("Не удалось создать хеш-таблицу.");
+    }
+}
+
+void IntegratorGUI::handleClearDriverTableOnly() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана.");
+        return;
+    }
+    int choice = fl_choice("Удалить хеш-таблицу водителей?", "Отмена", "Удалить", nullptr);
+    if (choice == 1) {
+        integrator_.clearDriverTable();
+        refreshDataViews();
+        updateStatus("Хеш-таблица удалена.");
+    }
+}
+
+void IntegratorGUI::handleShowDriverTable() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана.");
+        return;
+    }
+    std::string text = integrator_.hashTableAsText();
+    if (text.empty()) {
+        text = "<пусто>";
+    }
+    showTextWindow("Хеш-таблица водителей", text);
+}
+
 void IntegratorGUI::handleAddDriver() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана. Создайте таблицу перед добавлением водителей.");
+        return;
+    }
     auto record = promptDriver();
     if (!record) return;
 
@@ -501,6 +610,10 @@ void IntegratorGUI::handleAddDriver() {
 }
 
 void IntegratorGUI::handleUpdateDriver() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана. Создайте таблицу перед изменением водителей.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для изменения:");
     if (!license) return;
 
@@ -528,6 +641,10 @@ void IntegratorGUI::handleUpdateDriver() {
 }
 
 void IntegratorGUI::handleRemoveDriver() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана. Создайте таблицу перед удалением водителей.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для удаления:");
     if (!license) return;
 
@@ -546,6 +663,10 @@ void IntegratorGUI::handleRemoveDriver() {
 }
 
 void IntegratorGUI::handleFindDriver() {
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для поиска:");
     if (!license) return;
 
@@ -564,6 +685,10 @@ void IntegratorGUI::handleFindDriver() {
 }
 
 void IntegratorGUI::handleAddOrder() {
+    if (!integrator_.hasDriverTable() || !integrator_.hasOrderTree()) {
+        showError("Создайте хеш-таблицу и дерево заказов перед добавлением заказов.");
+        return;
+    }
     auto record = promptOrder();
     if (!record) return;
 
@@ -577,6 +702,14 @@ void IntegratorGUI::handleAddOrder() {
 }
 
 void IntegratorGUI::handleUpdateOrder() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
+    if (!integrator_.hasDriverTable()) {
+        showError("Хеш-таблица ещё не создана.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для выбора заказа:");
     if (!license) return;
 
@@ -610,6 +743,10 @@ void IntegratorGUI::handleUpdateOrder() {
 }
 
 void IntegratorGUI::handleRemoveOrder() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для удаления заказа:");
     if (!license) return;
 
@@ -645,6 +782,10 @@ void IntegratorGUI::handleRemoveOrder() {
 }
 
 void IntegratorGUI::handleShowOrders() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
     auto license = promptNonEmpty("Номер водителя для отображения заказов:");
     if (!license) return;
 
@@ -663,6 +804,10 @@ void IntegratorGUI::handleShowOrders() {
 }
 
 void IntegratorGUI::handleCheckOrder() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
     auto record = promptOrder();
     if (!record) return;
 
@@ -672,6 +817,63 @@ void IntegratorGUI::handleCheckOrder() {
     else {
         showInfo("Такого заказа нет.");
     }
+}
+
+void IntegratorGUI::handleCreateOrderTree() {
+    if (integrator_.createOrderTree()) {
+        refreshDataViews();
+        updateStatus("Дерево заказов создано.");
+    }
+    else {
+        showError("Не удалось создать дерево заказов.");
+    }
+}
+
+void IntegratorGUI::handleClearOrderTreeOnly() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
+    int choice = fl_choice("Удалить дерево заказов?", "Отмена", "Удалить", nullptr);
+    if (choice == 1) {
+        integrator_.clearOrderTree();
+        refreshDataViews();
+        updateStatus("Дерево заказов удалено.");
+    }
+}
+
+void IntegratorGUI::handleShowOrderTree() {
+    if (!integrator_.hasOrderTree()) {
+        showError("Дерево заказов ещё не создано.");
+        return;
+    }
+    std::string text = integrator_.orderTreeAsText();
+    if (text.empty()) {
+        text = "<пусто>";
+    }
+    showTextWindow("Дерево заказов", text);
+}
+
+void IntegratorGUI::handleGenerateReport() {
+    if (!integrator_.hasDriverTable() || !integrator_.hasOrderTree()) {
+        showError("Создайте обе структуры данных перед формированием отчёта.");
+        return;
+    }
+
+    auto license = promptNonEmpty("Номер лицензии для отчёта:");
+    if (!license) return;
+    auto carBrand = promptNonEmpty("Марка автомобиля:");
+    if (!carBrand) return;
+    auto address = promptNonEmpty("Адрес заказа:");
+    if (!address) return;
+    auto fromDate = promptString("Начальная дата (включительно, можно оставить пустым):", "");
+    if (!fromDate) return;
+    auto toDate = promptString("Конечная дата (включительно, можно оставить пустым):", "");
+    if (!toDate) return;
+
+    auto entries = integrator_.generateReport(*license, *carBrand, *address, *fromDate, *toDate);
+    std::string text = integrator_.formatReport(entries);
+    showTextWindow("Отчёт по водителю", text);
 }
 
 void IntegratorGUI::CallbackLoad(Fl_Widget*, void* data) {
@@ -688,6 +890,18 @@ void IntegratorGUI::CallbackSaveStructures(Fl_Widget*, void* data) {
 
 void IntegratorGUI::CallbackClear(Fl_Widget*, void* data) {
     static_cast<IntegratorGUI*>(data)->handleClear();
+}
+
+void IntegratorGUI::CallbackCreateDriverTable(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleCreateDriverTable();
+}
+
+void IntegratorGUI::CallbackClearDriverTableOnly(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleClearDriverTableOnly();
+}
+
+void IntegratorGUI::CallbackShowDriverTable(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleShowDriverTable();
 }
 
 void IntegratorGUI::CallbackAddDriver(Fl_Widget*, void* data) {
@@ -724,6 +938,22 @@ void IntegratorGUI::CallbackShowOrders(Fl_Widget*, void* data) {
 
 void IntegratorGUI::CallbackCheckOrder(Fl_Widget*, void* data) {
     static_cast<IntegratorGUI*>(data)->handleCheckOrder();
+}
+
+void IntegratorGUI::CallbackCreateOrderTree(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleCreateOrderTree();
+}
+
+void IntegratorGUI::CallbackClearOrderTreeOnly(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleClearOrderTreeOnly();
+}
+
+void IntegratorGUI::CallbackShowOrderTree(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleShowOrderTree();
+}
+
+void IntegratorGUI::CallbackGenerateReport(Fl_Widget*, void* data) {
+    static_cast<IntegratorGUI*>(data)->handleGenerateReport();
 }
 
 } // namespace

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -38,6 +38,8 @@ void RemoveIfExists(const std::filesystem::path& path) {
 
 TEST(DataIntegratorTest, IntegratorAddsDriverAndOrder) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-111111-2023", "Novikova Daria", "BMW", 10};
     OrderRecord order{driver.licenseNumber, "Ul. Lesnaya", "300 r.", "02 jan 2025"};
 
@@ -59,6 +61,8 @@ TEST(DataIntegratorTest, IntegratorAddsDriverAndOrder) {
 
 TEST(DataIntegratorTest, IntegratorRejectsOrderWithoutDriver) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     OrderRecord order{"TK-25-333333-2025", "Ul. Mira", "500 r.", "05 feb 2025"};
     EXPECT_FALSE(integrator.addOrder(order));
     EXPECT_EQ(integrator.orderCount(), 0u);
@@ -66,6 +70,8 @@ TEST(DataIntegratorTest, IntegratorRejectsOrderWithoutDriver) {
 
 TEST(DataIntegratorTest, IntegratorCascadesDriverRemoval) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-444444-2025", "Melnikov Igor", "Audi", 5};
     OrderRecord o1{driver.licenseNumber, "Ul. Mira", "400 r.", "10 feb 2025"};
     OrderRecord o2{driver.licenseNumber, "Ul. Lenina", "600 r.", "12 feb 2025"};
@@ -84,6 +90,8 @@ TEST(DataIntegratorTest, IntegratorCascadesDriverRemoval) {
 
 TEST(DataIntegratorTest, IntegratorMaintainsIndicesAfterOrderRemoval) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-555555-2025", "Sokolov Petr", "VW", 0};
     OrderRecord o1{driver.licenseNumber, "Street 1", "100 r.", "01 jan 2025"};
     OrderRecord o2{driver.licenseNumber, "Street 2", "200 r.", "02 jan 2025"};
@@ -104,6 +112,8 @@ TEST(DataIntegratorTest, IntegratorMaintainsIndicesAfterOrderRemoval) {
 
 TEST(DataIntegratorTest, IntegratorUpdatesOrderKey) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-666666-2025", "Alexeeva Olga", "Kia", 0};
     OrderRecord original{driver.licenseNumber, "Old Street", "150 r.", "01 mar 2025"};
     OrderRecord updated{driver.licenseNumber, "New Street", "155 r.", "02 mar 2025"};
@@ -122,6 +132,7 @@ TEST(DataIntegratorTest, IntegratorUpdatesOrderKey) {
 
 TEST(DataIntegratorTest, IntegratorUpdateDriverKeepsData) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
     DriverRecord driver{"TK-25-777777-2025", "Smirnov Ilya", "Ford", 0};
     ASSERT_TRUE(integrator.addDriver(driver));
 
@@ -137,6 +148,8 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
     DataIntegrator integrator;
     auto path = ConfigPath("valid_basic.cfg");
     ASSERT_TRUE(integrator.loadFromFile(path.string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     EXPECT_EQ(integrator.driverCount(), 50u);
     EXPECT_EQ(integrator.orderCount(), 50u);
@@ -167,6 +180,8 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
 TEST(DataIntegratorTest, IntegratorLoadsConfigMultiple) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_multiple.cfg").string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     EXPECT_EQ(integrator.driverCount(), 50u);
     EXPECT_EQ(integrator.orderCount(), 50u);
@@ -199,6 +214,8 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigMultiple) {
 TEST(DataIntegratorTest, IntegratorLoadsConfigNoOrders) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_no_orders.cfg").string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     EXPECT_EQ(integrator.driverCount(), 50u);
     EXPECT_EQ(integrator.orderCount(), 0u);
@@ -217,6 +234,8 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigNoOrders) {
 
 TEST(DataIntegratorTest, IntegratorSavesToFile) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord first{"DL-001", "Alpha Tester", "Tesla", 1};
     DriverRecord second{"DL-002", "Beta Tester", "BMW", 2};
     ASSERT_TRUE(integrator.addDriver(first));
@@ -252,6 +271,8 @@ TEST(DataIntegratorTest, IntegratorSavesToFile) {
 TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     auto driverOpt = integrator.findDriver("VB-100");
     ASSERT_TRUE(driverOpt.has_value());
@@ -295,6 +316,8 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
 
 TEST(DataIntegratorTest, IntegratorDumpsStructuresToText) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(32));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord alpha{"DL-HASH-1", "Alpha Tester", "Tesla", 1};
     DriverRecord beta{"DL-HASH-2", "Beta Tester", "Audi", 2};
     DriverRecord gamma{"DL-HASH-3", "Gamma Tester", "BMW", 3};
@@ -352,6 +375,7 @@ TEST(DataIntegratorTest, IntegratorDumpsStructuresToText) {
 
 TEST(DataIntegratorTest, IntegratorRejectsInvalidConfigFile) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
     DriverRecord existing{"SAFE-1", "Safe Driver", "VW", 3};
     ASSERT_TRUE(integrator.addDriver(existing));
     EXPECT_EQ(integrator.driverCount(), 1u);

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -42,12 +42,15 @@ TEST(DataIntegratorUseCasesTest, UseCase01_IntegratorStartsEmpty) {
 
     EXPECT_EQ(integrator.driverCount(), 0u);
     EXPECT_EQ(integrator.orderCount(), 0u);
+    EXPECT_FALSE(integrator.hasDriverTable());
+    EXPECT_FALSE(integrator.hasOrderTree());
     EXPECT_FALSE(integrator.hasDriver("ANY-DRIVER"));
     EXPECT_TRUE(integrator.ordersForDriver("ANY-DRIVER").empty());
 }
 
 TEST(DataIntegratorUseCasesTest, UseCase02_AddNovikovaDriver) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
     DriverRecord driver{"TK-25-111111-2023", "Novikova Daria", "BMW", 10};
 
     EXPECT_TRUE(integrator.addDriver(driver));
@@ -65,6 +68,7 @@ TEST(DataIntegratorUseCasesTest, UseCase02_AddNovikovaDriver) {
 
 TEST(DataIntegratorUseCasesTest, UseCase03_DuplicateDriverRejected) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
     DriverRecord driver{"TK-25-111111-2023", "Novikova Daria", "BMW", 10};
     ASSERT_TRUE(integrator.addDriver(driver));
 
@@ -78,6 +82,8 @@ TEST(DataIntegratorUseCasesTest, UseCase03_DuplicateDriverRejected) {
 TEST(DataIntegratorUseCasesTest, UseCase04_LoadBasicAndUpdateDriver) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_basic.cfg").string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     auto record = integrator.findDriver("VB-100");
     ASSERT_TRUE(record.has_value());
@@ -97,6 +103,8 @@ TEST(DataIntegratorUseCasesTest, UseCase04_LoadBasicAndUpdateDriver) {
 
 TEST(DataIntegratorUseCasesTest, UseCase05_DeleteDriverRemovesOrders) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-444444-2025", "Melnikov Igor", "Audi", 5};
     OrderRecord orderA{driver.licenseNumber, "Ul. Mira", "400 r.", "10 feb 2025"};
     OrderRecord orderB{driver.licenseNumber, "Ul. Lenina", "600 r.", "12 feb 2025"};
@@ -117,6 +125,8 @@ TEST(DataIntegratorUseCasesTest, UseCase05_DeleteDriverRemovesOrders) {
 
 TEST(DataIntegratorUseCasesTest, UseCase06_AddOrderForExistingDriver) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-111111-2023", "Novikova Daria", "BMW", 10};
     OrderRecord order{driver.licenseNumber, "Ul. Lesnaya", "300 r.", "02 jan 2025"};
 
@@ -131,6 +141,8 @@ TEST(DataIntegratorUseCasesTest, UseCase06_AddOrderForExistingDriver) {
 
 TEST(DataIntegratorUseCasesTest, UseCase07_AddOrderFailsWithoutDriver) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     OrderRecord order{"TK-25-333333-2025", "Ul. Mira", "500 r.", "05 feb 2025"};
 
     EXPECT_FALSE(integrator.addOrder(order));
@@ -139,6 +151,8 @@ TEST(DataIntegratorUseCasesTest, UseCase07_AddOrderFailsWithoutDriver) {
 
 TEST(DataIntegratorUseCasesTest, UseCase08_EditOrderFields) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-666666-2025", "Alexeeva Olga", "Kia", 0};
     OrderRecord original{driver.licenseNumber, "Old Street", "150 r.", "01 mar 2025"};
     OrderRecord updated{driver.licenseNumber, "New Street", "155 r.", "02 mar 2025"};
@@ -154,6 +168,8 @@ TEST(DataIntegratorUseCasesTest, UseCase08_EditOrderFields) {
 
 TEST(DataIntegratorUseCasesTest, UseCase09_ReassignOrderBetweenDrivers) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(32));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driverA{"DL-A", "Driver A", "Brand A", 1};
     DriverRecord driverB{"DL-B", "Driver B", "Brand B", 2};
     OrderRecord original{driverA.licenseNumber, "Main Square", "100", "2025-06-01"};
@@ -174,6 +190,8 @@ TEST(DataIntegratorUseCasesTest, UseCase09_ReassignOrderBetweenDrivers) {
 
 TEST(DataIntegratorUseCasesTest, UseCase10_DeleteMiddleOrder) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver{"TK-25-555555-2025", "Sokolov Petr", "VW", 0};
     OrderRecord order1{driver.licenseNumber, "Street 1", "100 r.", "01 jan 2025"};
     OrderRecord order2{driver.licenseNumber, "Street 2", "200 r.", "02 jan 2025"};
@@ -194,12 +212,81 @@ TEST(DataIntegratorUseCasesTest, UseCase10_DeleteMiddleOrder) {
 TEST(DataIntegratorUseCasesTest, UseCase11_LoadMultipleAndInspectVM200) {
     DataIntegrator integrator;
     ASSERT_TRUE(integrator.loadFromFile(ConfigPath("valid_multiple.cfg").string()));
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
 
     auto orders = integrator.ordersForDriver("VM-200");
     ASSERT_EQ(orders.size(), 3u);
     EXPECT_EQ(orders[0].address, "Multiple Hub 1A");
     EXPECT_EQ(orders[1].address, "Multiple Hub 1B");
     EXPECT_EQ(orders[2].address, "Multiple Hub 1C");
+}
+
+TEST(DataIntegratorUseCasesTest, UseCase12_CreateAndClearStructures) {
+    DataIntegrator integrator;
+
+    ASSERT_TRUE(integrator.createDriverTable(8));
+    ASSERT_TRUE(integrator.createOrderTree());
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
+
+    DriverRecord driver{"REP-100", "Reporter User", "Skoda", 0};
+    OrderRecord order{driver.licenseNumber, "Lenina 10", "700", "2025-04-01"};
+    ASSERT_TRUE(integrator.addDriver(driver));
+    ASSERT_TRUE(integrator.addOrder(order));
+
+    integrator.clearDriverTable();
+    EXPECT_FALSE(integrator.hasDriverTable());
+    EXPECT_EQ(integrator.driverCount(), 0u);
+    EXPECT_EQ(integrator.orderCount(), 1u);
+
+    integrator.clearOrderTree();
+    EXPECT_FALSE(integrator.hasOrderTree());
+    EXPECT_EQ(integrator.orderCount(), 0u);
+}
+
+TEST(DataIntegratorUseCasesTest, UseCase13_GenerateReportByCriteria) {
+    DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
+
+    DriverRecord driver{"REP-200", "Ivanov Petr", "Toyota", 5};
+    ASSERT_TRUE(integrator.addDriver(driver));
+
+    OrderRecord matchOrder{driver.licenseNumber, "Central Square", "800", "2025-02-15"};
+    OrderRecord laterOrder{driver.licenseNumber, "Central Square", "850", "2025-03-20"};
+    OrderRecord otherAddress{driver.licenseNumber, "Side Street", "400", "2025-02-10"};
+    ASSERT_TRUE(integrator.addOrder(matchOrder));
+    ASSERT_TRUE(integrator.addOrder(laterOrder));
+    ASSERT_TRUE(integrator.addOrder(otherAddress));
+
+    auto results = integrator.generateReport(driver.licenseNumber,
+                                             driver.carBrand,
+                                             matchOrder.address,
+                                             "2025-02-01",
+                                             "2025-02-28");
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_EQ(results.front().address, matchOrder.address);
+    EXPECT_EQ(results.front().date, matchOrder.date);
+
+    std::string formatted = integrator.formatReport(results);
+    EXPECT_NE(formatted.find(driver.fio), std::string::npos);
+    EXPECT_NE(formatted.find(matchOrder.date), std::string::npos);
+
+    auto none = integrator.generateReport(driver.licenseNumber,
+                                          "IncorrectBrand",
+                                          matchOrder.address,
+                                          "2025-02-01",
+                                          "2025-02-28");
+    EXPECT_TRUE(none.empty());
+
+    auto outsideRange = integrator.generateReport(driver.licenseNumber,
+                                                  driver.carBrand,
+                                                  matchOrder.address,
+                                                  "2025-03-01",
+                                                  "2025-03-30");
+    ASSERT_EQ(outsideRange.size(), 1u);
+    EXPECT_EQ(outsideRange.front().date, laterOrder.date);
 }
 
 TEST(DataIntegratorUseCasesTest, UseCase12_LoadMultipleDriversWithoutOrders) {
@@ -330,6 +417,8 @@ TEST(DataIntegratorUseCasesTest, UseCase21_UpdateOrderAndAddNewForDriver) {
 
 TEST(DataIntegratorUseCasesTest, UseCase22_SaveTwoDriversAndOrders) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driverA{"DL-001", "Alpha Tester", "Tesla", 1};
     DriverRecord driverB{"DL-002", "Beta Tester", "BMW", 2};
     OrderRecord orderA{driverA.licenseNumber, "Street 7", "100", "2024-12-31"};
@@ -442,6 +531,8 @@ TEST(DataIntegratorUseCasesTest, UseCase27_LoadNoOrdersShowsEmptyOrders) {
 
     EXPECT_EQ(integrator.driverCount(), 50u);
     EXPECT_EQ(integrator.orderCount(), 0u);
+    EXPECT_TRUE(integrator.hasDriverTable());
+    EXPECT_TRUE(integrator.hasOrderTree());
     EXPECT_TRUE(integrator.ordersForDriver("VN-300").empty());
     EXPECT_TRUE(integrator.ordersForDriver("VN-349").empty());
 }
@@ -449,6 +540,8 @@ TEST(DataIntegratorUseCasesTest, UseCase27_LoadNoOrdersShowsEmptyOrders) {
 namespace {
 
 void PrepareDiagnosticsData(DataIntegrator& integrator) {
+    ASSERT_TRUE(integrator.createDriverTable(32));
+    ASSERT_TRUE(integrator.createOrderTree());
     DriverRecord driver1{"DL-HASH-1", "Alpha Tester", "Tesla", 1};
     DriverRecord driver2{"DL-HASH-2", "Beta Tester", "Audi", 2};
     DriverRecord driver3{"DL-HASH-3", "Gamma Tester", "BMW", 3};
@@ -551,6 +644,7 @@ TEST(DataIntegratorUseCasesTest, UseCase30_SaveDiagnosticsBothStructures) {
 
 TEST(DataIntegratorUseCasesTest, UseCase31_LoadInvalidDoesNotOverwrite) {
     DataIntegrator integrator;
+    ASSERT_TRUE(integrator.createDriverTable(16));
     DriverRecord driver{"SAFE-1", "Safe Driver", "VW", 3};
     ASSERT_TRUE(integrator.addDriver(driver));
 


### PR DESCRIPTION
## Summary
- add lifecycle management for driver hash table and order tree in the GUI, including text inspectors and reporting
- update the data integrator to support creating/clearing structures, generating reports, and handling absent structures
- extend unit and use-case tests to cover the new behaviours and ensure compatibility

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68db84cfc4f883248c6825e43054e173