### PR TITLE
Switch GUI toolbars to menu bars and add load size prompt

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -391,7 +391,7 @@ void DataIntegrator::clear() {
     clearOrderTree();
 }
 
-bool DataIntegrator::loadFromFile(const std::string& path) {
+bool DataIntegrator::loadFromFile(const std::string& path, std::size_t initialDriverTableSize) {
     std::ifstream input(path);
     if (!input.is_open()) return false;
 
@@ -426,8 +426,13 @@ bool DataIntegrator::loadFromFile(const std::string& path) {
         parsedOrders.push_back(record);
     }
 
-    DataIntegrator temp(driverTable_.capacity(), driverTableMaxLoadFactor_);
-    temp.createDriverTable(driverTable_.capacity());
+    std::size_t tableCapacity = driverTable_.capacity();
+    if (initialDriverTableSize > 0) {
+        tableCapacity = initialDriverTableSize;
+    }
+
+    DataIntegrator temp(tableCapacity, driverTableMaxLoadFactor_);
+    temp.createDriverTable(tableCapacity);
     temp.createOrderTree();
 
     bool driversLoaded = true;

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -51,7 +51,7 @@ public:
 
     void clear();
 
-    bool loadFromFile(const std::string& path);
+    bool loadFromFile(const std::string& path, std::size_t initialDriverTableSize = 0);
     bool saveToFile(const std::string& path) const;
     std::string hashTableAsText() const;
     std::string orderTreeAsText() const;

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -4,9 +4,8 @@
 
 #include <FL/Fl.H>
 #include <FL/Fl_Box.H>
-#include <FL/Fl_Button.H>
 #include <FL/Fl_Double_Window.H>
-#include <FL/Fl_Group.H>
+#include <FL/Fl_Menu_Bar.H>
 #include <FL/Fl_Native_File_Chooser.H>
 #include <FL/Fl_Text_Buffer.H>
 #include <FL/Fl_Text_Display.H>
@@ -33,8 +32,8 @@ private:
 
     Fl_Double_Window* hashWindow_;
     Fl_Double_Window* treeWindow_;
-    Fl_Group*         hashToolStrip_;
-    Fl_Group*         treeToolStrip_;
+    Fl_Menu_Bar*      hashMenuBar_;
+    Fl_Menu_Bar*      treeMenuBar_;
     Fl_Text_Display*  hashDisplay_;
     Fl_Text_Display*  treeDisplay_;
     Fl_Text_Buffer*   hashBuffer_;
@@ -108,8 +107,8 @@ IntegratorGUI::IntegratorGUI()
     : integrator_(),
       hashWindow_(nullptr),
       treeWindow_(nullptr),
-      hashToolStrip_(nullptr),
-      treeToolStrip_(nullptr),
+      hashMenuBar_(nullptr),
+      treeMenuBar_(nullptr),
       hashDisplay_(nullptr),
       treeDisplay_(nullptr),
       hashBuffer_(nullptr),
@@ -119,55 +118,34 @@ IntegratorGUI::IntegratorGUI()
     const int windowWidth = 700;
     const int windowHeight = 700;
 
-    const int buttonWidth = 160;
-    const int buttonHeight = 28;
-    const int buttonSpacing = 10;
-    const int toolStripHeight = 140;
-
-    auto createToolbarButton = [&](Fl_Group* strip, int& x, int& y, const char* label, Fl_Callback* cb) {
-        if (x + buttonWidth > strip->w() - 10) {
-            x = 10;
-            y += buttonHeight + buttonSpacing;
-        }
-        Fl_Button* button = new Fl_Button(strip->x() + x, strip->y() + y, buttonWidth, buttonHeight, label);
-        button->callback(cb, this);
-        x += buttonWidth + buttonSpacing;
-        return button;
-    };
-
     hashWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Водители (хеш-таблица)");
     hashWindow_->begin();
 
-    hashToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    hashToolStrip_->box(FL_THIN_UP_BOX);
-    hashToolStrip_->color(fl_rgb_color(245, 245, 245));
-    hashToolStrip_->begin();
+    const int menuBarHeight = 32;
+    hashMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuBarHeight);
+    hashMenuBar_->box(FL_THIN_UP_BOX);
+    hashMenuBar_->color(fl_rgb_color(245, 245, 245));
+    hashMenuBar_->textsize(13);
+    hashMenuBar_->add("Загр. из файла", 0, &IntegratorGUI::CallbackLoad, this);
+    hashMenuBar_->add("Выгр. в файл", 0, &IntegratorGUI::CallbackSave, this);
+    hashMenuBar_->add("Доб", 0, &IntegratorGUI::CallbackAddDriver, this);
+    hashMenuBar_->add("Изм", 0, &IntegratorGUI::CallbackUpdateDriver, this);
+    hashMenuBar_->add("Найти", 0, &IntegratorGUI::CallbackFindDriver, this);
+    hashMenuBar_->add("Удалить", 0, &IntegratorGUI::CallbackRemoveDriver, this);
+    hashMenuBar_->add("Отч", 0, &IntegratorGUI::CallbackSaveStructures, this);
+    hashMenuBar_->add("Табл", 0, &IntegratorGUI::CallbackShowDriverTable, this);
+    hashMenuBar_->add("Созд Табл", 0, &IntegratorGUI::CallbackCreateDriverTable, this);
+    hashMenuBar_->add("Удалить Табл", 0, &IntegratorGUI::CallbackClearDriverTableOnly, this);
+    hashMenuBar_->add("Очистить", 0, &IntegratorGUI::CallbackClear, this);
 
-    int hashButtonX = 10;
-    int hashButtonY = 10;
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Загрузить...", &IntegratorGUI::CallbackLoad);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить...", &IntegratorGUI::CallbackSave);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Сохранить структуры...", &IntegratorGUI::CallbackSaveStructures);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Очистить", &IntegratorGUI::CallbackClear);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Создать таблицу", &IntegratorGUI::CallbackCreateDriverTable);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Удалить таблицу", &IntegratorGUI::CallbackClearDriverTableOnly);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Показать таблицу", &IntegratorGUI::CallbackShowDriverTable);
-
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Добавить водителя", &IntegratorGUI::CallbackAddDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Изменить водителя", &IntegratorGUI::CallbackUpdateDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Удалить водителя", &IntegratorGUI::CallbackRemoveDriver);
-    createToolbarButton(hashToolStrip_, hashButtonX, hashButtonY, "Найти водителя", &IntegratorGUI::CallbackFindDriver);
-
-    hashToolStrip_->end();
-
-    hashStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    hashStatusBox_ = new Fl_Box(10, menuBarHeight + 5, windowWidth - 20, 30);
     hashStatusBox_->box(FL_THIN_DOWN_BOX);
     hashStatusBox_->labelfont(FL_HELVETICA_BOLD);
     hashStatusBox_->labelsize(14);
     hashStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     hashStatusBox_->copy_label("Готово.");
 
-    const int hashContentTop = toolStripHeight + 40;
+    const int hashContentTop = menuBarHeight + 40;
     const int hashContentHeight = windowHeight - hashContentTop - 10;
 
     Fl_Box* hashLabel = new Fl_Box(10, hashContentTop, windowWidth - 20, 25, "Хеш-таблица водителей");
@@ -187,33 +165,28 @@ IntegratorGUI::IntegratorGUI()
     treeWindow_ = new Fl_Double_Window(windowWidth, windowHeight, "Заказы (AVL-дерево)");
     treeWindow_->begin();
 
-    treeToolStrip_ = new Fl_Group(0, 0, windowWidth, toolStripHeight);
-    treeToolStrip_->box(FL_THIN_UP_BOX);
-    treeToolStrip_->color(fl_rgb_color(245, 245, 245));
-    treeToolStrip_->begin();
+    treeMenuBar_ = new Fl_Menu_Bar(0, 0, windowWidth, menuBarHeight);
+    treeMenuBar_->box(FL_THIN_UP_BOX);
+    treeMenuBar_->color(fl_rgb_color(245, 245, 245));
+    treeMenuBar_->textsize(13);
+    treeMenuBar_->add("Доб", 0, &IntegratorGUI::CallbackAddOrder, this);
+    treeMenuBar_->add("Изм", 0, &IntegratorGUI::CallbackUpdateOrder, this);
+    treeMenuBar_->add("Найти", 0, &IntegratorGUI::CallbackCheckOrder, this);
+    treeMenuBar_->add("Удалить", 0, &IntegratorGUI::CallbackRemoveOrder, this);
+    treeMenuBar_->add("Отч", 0, &IntegratorGUI::CallbackShowOrders, this);
+    treeMenuBar_->add("Табл", 0, &IntegratorGUI::CallbackShowOrderTree, this);
+    treeMenuBar_->add("Созд Табл", 0, &IntegratorGUI::CallbackCreateOrderTree, this);
+    treeMenuBar_->add("Удалить Табл", 0, &IntegratorGUI::CallbackClearOrderTreeOnly, this);
+    treeMenuBar_->add("Заказы (Генерация отчётов)", 0, &IntegratorGUI::CallbackGenerateReport, this);
 
-    int treeButtonX = 10;
-    int treeButtonY = 10;
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Добавить заказ", &IntegratorGUI::CallbackAddOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Изменить заказ", &IntegratorGUI::CallbackUpdateOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить заказ", &IntegratorGUI::CallbackRemoveOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Заказы водителя", &IntegratorGUI::CallbackShowOrders);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Проверить заказ", &IntegratorGUI::CallbackCheckOrder);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Создать дерево", &IntegratorGUI::CallbackCreateOrderTree);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Удалить дерево", &IntegratorGUI::CallbackClearOrderTreeOnly);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Показать дерево", &IntegratorGUI::CallbackShowOrderTree);
-    createToolbarButton(treeToolStrip_, treeButtonX, treeButtonY, "Сформировать отчёт", &IntegratorGUI::CallbackGenerateReport);
-
-    treeToolStrip_->end();
-
-    treeStatusBox_ = new Fl_Box(10, toolStripHeight + 5, windowWidth - 20, 30);
+    treeStatusBox_ = new Fl_Box(10, menuBarHeight + 5, windowWidth - 20, 30);
     treeStatusBox_->box(FL_THIN_DOWN_BOX);
     treeStatusBox_->labelfont(FL_HELVETICA_BOLD);
     treeStatusBox_->labelsize(14);
     treeStatusBox_->align(FL_ALIGN_INSIDE | FL_ALIGN_LEFT);
     treeStatusBox_->copy_label("Готово.");
 
-    const int treeContentTop = toolStripHeight + 40;
+    const int treeContentTop = menuBarHeight + 40;
     const int treeContentHeight = windowHeight - treeContentTop - 10;
 
     Fl_Box* treeLabel = new Fl_Box(10, treeContentTop, windowWidth - 20, 25, "Дерево заказов (AVL)");
@@ -497,7 +470,15 @@ void IntegratorGUI::handleLoad() {
                                false);
     if (!path) return;
 
-    if (integrator_.loadFromFile(*path)) {
+    std::size_t capacity = integrator_.driverTableCapacity();
+    if (capacity == 0) {
+        capacity = 1;
+    }
+    int defaultSize = static_cast<int>(capacity);
+    auto sizeOpt = promptInt("Начальный размер хеш-таблицы:", defaultSize, 1);
+    if (!sizeOpt) return;
+
+    if (integrator_.loadFromFile(*path, static_cast<std::size_t>(*sizeOpt))) {
         updateStatus("Файл успешно загружен.");
         refreshDataViews();
         showInfo("Данные загружены.");


### PR DESCRIPTION
## Summary
- replace the hash table and order windows' button strips with single-row menu bars using the requested labels
- ask for the initial hash table size before loading from a file and forward the choice to the integrator
- extend DataIntegrator::loadFromFile with an optional initial size parameter used by the GUI

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dbd574c8d4832482f94780b06b209e