### PR TITLE
Refactor validation and unify date handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(cursedarch STATIC
     DoublyLinkedList.cpp
     data_integrator.cpp
     string_utils.cpp
+    validation.cpp
 )
 
 target_include_directories(cursedarch

--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "string_utils.hpp"
+#include "validation.hpp"
 
 namespace {
 
@@ -17,9 +18,13 @@ bool parseDriverLine(const std::string& line, DriverRecord& out) {
     for (std::size_t i = 0; i < 3; ++i) {
         string_utils::trimCarriageReturn(parts[i]);
         string_utils::stripUtf8Bom(parts[i]);
+        parts[i] = string_utils::trim(parts[i]);
     }
 
-    if (parts[0].empty()) return false;
+    if (!validation::isValidLicense(parts[0]) || !validation::isValidFio(parts[1])
+        || !validation::isValidCarBrand(parts[2])) {
+        return false;
+    }
 
     out.licenseNumber = parts[0];
     out.fio = parts[1];
@@ -33,17 +38,18 @@ bool parseOrderLine(const std::string& line, OrderRecord& out) {
     for (std::size_t i = 0; i < 4; ++i) {
         string_utils::trimCarriageReturn(parts[i]);
         string_utils::stripUtf8Bom(parts[i]);
+        parts[i] = string_utils::trim(parts[i]);
     }
 
-    if (parts[0].empty()) return false;
+    Date parsed{};
+    if (!validation::isValidLicense(parts[0]) || !validation::isValidAddress(parts[1])
+        || !validation::isValidCost(parts[2]) || !validation::parseDate(parts[3], parsed)) {
+        return false;
+    }
 
     out.licenseNumber = parts[0];
     out.address = parts[1];
     out.cost = parts[2];
-    Date parsed{};
-    if (!Date::parse(parts[3], parsed)) {
-        return false;
-    }
     out.date = parsed;
     return true;
 }
@@ -194,10 +200,18 @@ void appendDateNodeDetailed(const AVLNode*                     node,
 
     std::string label = node->license;
     if (label.size() == 8) {
-        std::string iso = label.substr(0, 4) + "-" + label.substr(4, 2) + "-" + label.substr(6, 2);
-        Date parsed{};
-        if (Date::parse(iso, parsed)) {
-            label = parsed.displayString();
+        int year = 0;
+        int month = 0;
+        int day = 0;
+        if (string_utils::parseInteger(label.substr(0, 4), year)
+            && string_utils::parseInteger(label.substr(4, 2), month)
+            && string_utils::parseInteger(label.substr(6, 2), day)) {
+            if (month >= 1 && month <= 12) {
+                Date parsed(day, static_cast<Month>(month), year);
+                if (parsed.isValid()) {
+                    label = parsed.displayString();
+                }
+            }
         }
     }
     out << label << '\n';

--- a/date.hpp
+++ b/date.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iomanip>
+#include <regex>
 #include <sstream>
 #include <string>
 
@@ -35,12 +36,22 @@ struct Date {
             return false;
         }
 
-        Date parsed{};
-        if (parseIso(trimmed, parsed) || parseText(trimmed, parsed)) {
-            out = parsed;
-            return true;
+        static const std::regex pattern(
+            R"(^(0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4})$)");
+        std::smatch match;
+        if (!std::regex_match(trimmed, match, pattern)) {
+            return false;
         }
-        return false;
+
+        int dayValue = std::stoi(match[1].str());
+        int yearValue = std::stoi(match[3].str());
+        Month monthValue;
+        if (!parseMonth(match[2].str(), monthValue)) {
+            return false;
+        }
+
+        out = Date(dayValue, monthValue, yearValue);
+        return out.isValid();
     }
 
     std::string displayString() const {
@@ -51,10 +62,7 @@ struct Date {
     }
 
     std::string storageString() const {
-        std::ostringstream out;
-        out << std::setfill('0') << std::setw(4) << year << '-' << std::setw(2)
-            << static_cast<int>(month) << '-' << std::setw(2) << day;
-        return out.str();
+        return displayString();
     }
 
     std::string key() const {
@@ -86,59 +94,12 @@ private:
         return MONTH_NAMES[index];
     }
 
-    static bool parseIso(const std::string& text, Date& out) {
-        std::size_t firstDash = text.find('-');
-        if (firstDash == std::string::npos) return false;
-        std::size_t secondDash = text.find('-', firstDash + 1);
-        if (secondDash == std::string::npos) return false;
-
-        std::string yearPart = text.substr(0, firstDash);
-        std::string monthPart = text.substr(firstDash + 1, secondDash - firstDash - 1);
-        std::string dayPart = text.substr(secondDash + 1);
-
-        int yearValue = 0;
-        int monthValue = 0;
-        int dayValue = 0;
-        if (!string_utils::parseInteger(yearPart, yearValue)) return false;
-        if (!string_utils::parseInteger(monthPart, monthValue)) return false;
-        if (!string_utils::parseInteger(dayPart, dayValue)) return false;
-
-        if (monthValue < 1 || monthValue > 12) return false;
-        if (dayValue < 1 || dayValue > 31) return false;
-
-        out = Date(dayValue, static_cast<Month>(monthValue), yearValue);
-        return true;
-    }
-
-    static bool parseText(const std::string& text, Date& out) {
-        std::istringstream input(text);
-        std::string      dayPart;
-        std::string      monthPart;
-        std::string      yearPart;
-        if (!(input >> dayPart >> monthPart >> yearPart)) {
-            return false;
-        }
-
-        int dayValue = 0;
-        int yearValue = 0;
-        if (!string_utils::parseInteger(dayPart, dayValue)) return false;
-        if (dayValue < 1 || dayValue > 31) return false;
-        if (!string_utils::parseInteger(yearPart, yearValue)) return false;
-
-        Month monthValue;
-        if (!parseMonth(monthPart, monthValue)) return false;
-
-        out = Date(dayValue, monthValue, yearValue);
-        return true;
-    }
-
     static bool parseMonth(const std::string& text, Month& month) {
         static const char* MONTH_NAMES[12] = {
-            "jan", "feb", "mar", "apr", "may", "jun",
-            "jul", "aug", "sep", "oct", "nov", "dec"};
-        std::string lower = string_utils::toLower(text);
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
         for (int i = 0; i < 12; ++i) {
-            if (lower == MONTH_NAMES[i]) {
+            if (text == MONTH_NAMES[i]) {
                 month = static_cast<Month>(i + 1);
                 return true;
             }

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -19,299 +19,18 @@
 #include <FL/fl_draw.H>
 
 #include <algorithm>
+#include <cstdlib>
+#include <fstream>
 #include <functional>
 #include <optional>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "data_integrator.hpp"
+#include "validation.hpp"
 
 namespace {
-
-constexpr char32_t kCyrillicUpperA = U'\u0410';
-constexpr char32_t kCyrillicUpperYa = U'\u042F';
-constexpr char32_t kCyrillicLowerA = U'\u0430';
-constexpr char32_t kCyrillicLowerYa = U'\u044F';
-constexpr char32_t kCyrillicUpperYo = U'\u0401';
-constexpr char32_t kCyrillicLowerYo = U'\u0451';
-
-bool decodeUtf8(const std::string& text, std::u32string& out) {
-    out.clear();
-
-    std::size_t i = 0;
-    while (i < text.size()) {
-        unsigned char byte = static_cast<unsigned char>(text[i]);
-        char32_t codePoint = 0;
-        std::size_t remaining = 0;
-
-        if ((byte & 0x80) == 0) {
-            codePoint = byte;
-            remaining = 0;
-        }
-        else if ((byte & 0xE0) == 0xC0) {
-            codePoint = byte & 0x1F;
-            remaining = 1;
-        }
-        else if ((byte & 0xF0) == 0xE0) {
-            codePoint = byte & 0x0F;
-            remaining = 2;
-        }
-        else if ((byte & 0xF8) == 0xF0) {
-            codePoint = byte & 0x07;
-            remaining = 3;
-        }
-        else {
-            return false;
-        }
-
-        if (i + remaining >= text.size()) {
-            return false;
-        }
-
-        for (std::size_t j = 0; j < remaining; ++j) {
-            unsigned char continuation = static_cast<unsigned char>(text[i + j + 1]);
-            if ((continuation & 0xC0) != 0x80) {
-                return false;
-            }
-            codePoint = (codePoint << 6) | (continuation & 0x3F);
-        }
-
-        if ((remaining == 1 && codePoint < 0x80) || (remaining == 2 && codePoint < 0x800)
-            || (remaining == 3 && codePoint < 0x10000)) {
-            return false;
-        }
-
-        if (codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
-            return false;
-        }
-
-        out.push_back(codePoint);
-        i += remaining + 1;
-    }
-
-    return true;
-}
-
-bool isDigit(char32_t codePoint) {
-    return codePoint >= U'0' && codePoint <= U'9';
-}
-
-bool isLatinUpper(char32_t codePoint) {
-    return codePoint >= U'A' && codePoint <= U'Z';
-}
-
-bool isLatinLower(char32_t codePoint) {
-    return codePoint >= U'a' && codePoint <= U'z';
-}
-
-bool isRussianUpper(char32_t codePoint) {
-    return (codePoint >= kCyrillicUpperA && codePoint <= kCyrillicUpperYa) || codePoint == kCyrillicUpperYo;
-}
-
-bool isRussianLower(char32_t codePoint) {
-    return (codePoint >= kCyrillicLowerA && codePoint <= kCyrillicLowerYa) || codePoint == kCyrillicLowerYo;
-}
-
-bool isRussianLetter(char32_t codePoint) {
-    return isRussianUpper(codePoint) || isRussianLower(codePoint);
-}
-
-bool splitBySpaces(const std::string& value, std::vector<std::string>& words) {
-    words.clear();
-    if (value.empty() || value.front() == ' ' || value.back() == ' ') {
-        return false;
-    }
-
-    std::size_t start = 0;
-    while (start < value.size()) {
-        std::size_t end = value.find(' ', start);
-        std::size_t length = (end == std::string::npos) ? value.size() - start : end - start;
-        if (length == 0) {
-            return false;
-        }
-        words.emplace_back(value.substr(start, length));
-        if (end == std::string::npos) {
-            break;
-        }
-        start = end + 1;
-    }
-
-    return true;
-}
-
-bool isValidLicense(const std::string& value) {
-    if (value.empty()) {
-        return false;
-    }
-    for (char ch : value) {
-        if (!(ch >= 'A' && ch <= 'Z') && !(ch >= '0' && ch <= '9')) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool isValidFio(const std::string& value) {
-    std::vector<std::string> parts;
-    if (!splitBySpaces(value, parts) || parts.size() != 3) {
-        return false;
-    }
-
-    for (const std::string& part : parts) {
-        std::u32string codePoints;
-        if (!decodeUtf8(part, codePoints) || codePoints.empty()) {
-            return false;
-        }
-        if (!isRussianUpper(codePoints.front())) {
-            return false;
-        }
-        for (std::size_t i = 1; i < codePoints.size(); ++i) {
-            if (!isRussianLower(codePoints[i])) {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-bool isValidCarBrand(const std::string& value) {
-    if (value.empty() || value.find(' ') != std::string::npos) {
-        return false;
-    }
-
-    std::u32string codePoints;
-    if (!decodeUtf8(value, codePoints) || codePoints.empty()) {
-        return false;
-    }
-
-    bool useLatin = false;
-    if (isLatinUpper(codePoints.front())) {
-        useLatin = true;
-    }
-    else if (!isRussianUpper(codePoints.front())) {
-        return false;
-    }
-
-    for (std::size_t i = 1; i < codePoints.size(); ++i) {
-        char32_t cp = codePoints[i];
-        if (useLatin) {
-            if (!isLatinLower(cp)) {
-                return false;
-            }
-        }
-        else {
-            if (!isRussianLower(cp)) {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-bool isValidAddress(const std::string& value) {
-    std::vector<std::string> tokens;
-    if (!splitBySpaces(value, tokens) || tokens.empty()) {
-        return false;
-    }
-
-    bool first = true;
-    for (const std::string& token : tokens) {
-        std::string core = token;
-        while (!core.empty() && (core.back() == '.' || core.back() == ',')) {
-            core.pop_back();
-        }
-        if (core.empty()) {
-            return false;
-        }
-
-        std::u32string codePoints;
-        if (!decodeUtf8(core, codePoints) || codePoints.empty()) {
-            return false;
-        }
-
-        bool hasLetters = false;
-        bool hasDigits = false;
-        for (char32_t cp : codePoints) {
-            if (isDigit(cp)) {
-                hasDigits = true;
-            }
-            else if (isRussianLetter(cp)) {
-                hasLetters = true;
-            }
-            else {
-                return false;
-            }
-        }
-
-        if (hasLetters && hasDigits) {
-            return false;
-        }
-
-        if (hasLetters) {
-            if (!isRussianUpper(codePoints.front())) {
-                return false;
-            }
-            for (std::size_t i = 1; i < codePoints.size(); ++i) {
-                if (!isRussianLower(codePoints[i])) {
-                    return false;
-                }
-            }
-        }
-        else {
-            if (first) {
-                return false;
-            }
-        }
-
-        first = false;
-    }
-
-    return true;
-}
-
-bool isValidCost(const std::string& value) {
-    if (value.empty()) {
-        return false;
-    }
-
-    std::size_t commaPos = value.find(',');
-    if (commaPos == std::string::npos) {
-        return false;
-    }
-
-    std::string integerPart = value.substr(0, commaPos);
-    std::string fractionalPart = value.substr(commaPos + 1);
-
-    if (integerPart.empty() || fractionalPart.size() != 2) {
-        return false;
-    }
-
-    if (!std::all_of(integerPart.begin(), integerPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })
-        || !std::all_of(fractionalPart.begin(), fractionalPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })) {
-        return false;
-    }
-
-    bool integerAllZeros = std::all_of(integerPart.begin(), integerPart.end(), [](char ch) { return ch == '0'; });
-    if (integerAllZeros && fractionalPart == "00") {
-        return false;
-    }
-
-    return true;
-}
-
-bool parseStrictDate(const std::string& text, Date& out) {
-    static const std::regex pattern(
-        R"(^(0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4})$)");
-    if (!std::regex_match(text, pattern)) {
-        return false;
-    }
-    return Date::parse(text, out);
-}
-
 class DriverTableView : public Fl_Table_Row {
 public:
     DriverTableView(int X, int Y, int W, int H, DataIntegrator& integrator)
@@ -493,7 +212,7 @@ private:
     void updateStatus(const std::string& message);
     void showInfo(const std::string& message);
     void showError(const std::string& message);
-    void showTextWindow(const std::string& title, const std::string& content);
+    void showTextWindow(const std::string& title, const std::string& content, bool allowSave = false);
 
     std::optional<std::string> promptNonEmpty(const char* prompt, const std::string& initial = "");
     std::optional<std::string> promptString(const char* prompt, const std::string& initial = "");
@@ -752,23 +471,74 @@ void IntegratorGUI::showError(const std::string& message) {
     fl_alert("%s", message.c_str());
 }
 
-void IntegratorGUI::showTextWindow(const std::string& title, const std::string& content) {
+void IntegratorGUI::showTextWindow(const std::string& title, const std::string& content, bool allowSave) {
+    struct TextWindowContext {
+        Fl_Text_Display* display;
+        Fl_Text_Buffer*  buffer;
+    };
+
     Fl_Double_Window* window = new Fl_Double_Window(640, 480, title.c_str());
     window->begin();
-    Fl_Text_Display* display = new Fl_Text_Display(10, 10, 620, 430);
+    Fl_Text_Display* display = new Fl_Text_Display(10, 10, 620, allowSave ? 420 : 460);
     display->box(FL_DOWN_BOX);
     display->textfont(FL_COURIER);
     display->textsize(13);
     Fl_Text_Buffer* buffer = new Fl_Text_Buffer();
     buffer->text(content.c_str());
     display->buffer(buffer);
+
+    auto* context = new TextWindowContext{display, buffer};
+
+    if (allowSave) {
+        Fl_Button* saveButton = new Fl_Button(10, 440, 140, 30, "Сохранить...");
+        saveButton->callback([](Fl_Widget*, void* data) {
+            auto* ctx = static_cast<TextWindowContext*>(data);
+            if (!ctx || !ctx->buffer) {
+                return;
+            }
+
+            Fl_Native_File_Chooser chooser(Fl_Native_File_Chooser::BROWSE_SAVE_FILE);
+            chooser.options(Fl_Native_File_Chooser::SAVEAS_CONFIRM);
+            chooser.title("Сохранить отчёт");
+            chooser.filter("Text Files\t*.txt\nAll Files\t*.*\n");
+
+            if (chooser.show() != 0) {
+                return;
+            }
+
+            const char* filename = chooser.filename();
+            if (!filename || !*filename) {
+                return;
+            }
+
+            std::ofstream output(filename, std::ios::binary);
+            if (!output) {
+                fl_message_title("Ошибка");
+                fl_alert("Не удалось открыть файл для записи.");
+                return;
+            }
+
+            char* textPtr = ctx->buffer->text();
+            std::string toWrite;
+            if (textPtr) {
+                toWrite.assign(textPtr);
+                std::free(textPtr);
+            }
+
+            output << toWrite;
+            if (!output) {
+                fl_message_title("Ошибка");
+                fl_alert("Не удалось сохранить файл полностью.");
+                return;
+            }
+
+            fl_message_title("Сохранено");
+            fl_message("Отчёт сохранён.");
+        }, context);
+    }
+
     window->resizable(display);
     window->end();
-    struct TextWindowContext {
-        Fl_Text_Display* display;
-        Fl_Text_Buffer*  buffer;
-    };
-    auto* context = new TextWindowContext{display, buffer};
     window->callback([](Fl_Widget* widget, void* data) {
         auto* ctx = static_cast<TextWindowContext*>(data);
         if (ctx) {
@@ -840,7 +610,7 @@ std::optional<std::string> IntegratorGUI::promptLicense(const char* prompt,
                                                         bool allowEmpty) {
     return promptValidated(prompt,
                            initial,
-                           isValidLicense,
+                           validation::isValidLicense,
                            "Номер лицензии должен состоять из заглавных латинских букв и цифр без пробелов.",
                            allowEmpty);
 }
@@ -848,7 +618,7 @@ std::optional<std::string> IntegratorGUI::promptLicense(const char* prompt,
 std::optional<std::string> IntegratorGUI::promptFio(const char* prompt, const std::string& initial) {
     return promptValidated(prompt,
                            initial,
-                           isValidFio,
+                           validation::isValidFio,
                            "ФИО должно состоять из трёх слов: первая буква заглавная, остальные строчные.");
 }
 
@@ -857,7 +627,7 @@ std::optional<std::string> IntegratorGUI::promptCarBrand(const char* prompt,
                                                          bool allowEmpty) {
     return promptValidated(prompt,
                            initial,
-                           isValidCarBrand,
+                           validation::isValidCarBrand,
                            "Марка должна быть одним словом из букв: первая буква заглавная, остальные строчные.",
                            allowEmpty);
 }
@@ -867,7 +637,7 @@ std::optional<std::string> IntegratorGUI::promptAddress(const char* prompt,
                                                         bool allowEmpty) {
     return promptValidated(prompt,
                            initial,
-                           isValidAddress,
+                           validation::isValidAddress,
                            "Адрес должен состоять из слов на русском языке с одинарными пробелами и допустимой пунктуацией.",
                            allowEmpty);
 }
@@ -875,7 +645,7 @@ std::optional<std::string> IntegratorGUI::promptAddress(const char* prompt,
 std::optional<std::string> IntegratorGUI::promptCost(const char* prompt, const std::string& initial) {
     return promptValidated(prompt,
                            initial,
-                           isValidCost,
+                           validation::isValidCost,
                            "Стоимость должна быть положительным числом с двумя знаками после запятой (пример: 350,00).");
 }
 
@@ -887,7 +657,7 @@ std::optional<Date> IntegratorGUI::promptDate(const char* prompt, const std::str
             return std::nullopt;
         }
         Date parsed{};
-        if (parseStrictDate(*value, parsed)) {
+        if (validation::parseDate(*value, parsed)) {
             return parsed;
         }
         showError("Введите дату в формате DD Mon YYYY (пример: 05 Nov 2025).");
@@ -1448,7 +1218,7 @@ void IntegratorGUI::handleGenerateReport() {
                                     "",
                                     [](const std::string& value) {
                                         Date parsed{};
-                                        return parseStrictDate(value, parsed);
+                                        return validation::parseDate(value, parsed);
                                     },
                                     "Дата должна быть в формате DD Mon YYYY (пример: 05 Nov 2025).",
                                     true);
@@ -1457,7 +1227,7 @@ void IntegratorGUI::handleGenerateReport() {
                                   "",
                                   [](const std::string& value) {
                                       Date parsed{};
-                                      return parseStrictDate(value, parsed);
+                                      return validation::parseDate(value, parsed);
                                   },
                                   "Дата должна быть в формате DD Mon YYYY (пример: 05 Nov 2025).",
                                   true);
@@ -1465,7 +1235,7 @@ void IntegratorGUI::handleGenerateReport() {
 
     DoublyLinkedList<ReportEntry> entries = integrator_.generateReport(*license, *carBrand, *address, *fromDate, *toDate);
     std::string text = integrator_.formatReport(entries);
-    showTextWindow("Отчёт по водителю", text);
+    showTextWindow("Отчёт по водителю", text, true);
 }
 
 void IntegratorGUI::CallbackLoadDrivers(Fl_Widget*, void* data) {

--- a/string_utils.cpp
+++ b/string_utils.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <vector>
 
 namespace string_utils {
 
@@ -72,6 +74,86 @@ bool splitLine(const std::string& line, char delimiter, std::string* fields, std
         start = i + 1;
     }
     return fieldIndex == expectedCount;
+}
+
+bool decodeUtf8(const std::string& text, std::u32string& out) {
+    out.clear();
+
+    std::size_t i = 0;
+    while (i < text.size()) {
+        unsigned char byte = static_cast<unsigned char>(text[i]);
+        char32_t      codePoint = 0;
+        std::size_t   remaining = 0;
+
+        if ((byte & 0x80) == 0) {
+            codePoint = byte;
+            remaining = 0;
+        }
+        else if ((byte & 0xE0) == 0xC0) {
+            codePoint = byte & 0x1F;
+            remaining = 1;
+        }
+        else if ((byte & 0xF0) == 0xE0) {
+            codePoint = byte & 0x0F;
+            remaining = 2;
+        }
+        else if ((byte & 0xF8) == 0xF0) {
+            codePoint = byte & 0x07;
+            remaining = 3;
+        }
+        else {
+            return false;
+        }
+
+        if (i + remaining >= text.size()) {
+            return false;
+        }
+
+        for (std::size_t j = 0; j < remaining; ++j) {
+            unsigned char continuation = static_cast<unsigned char>(text[i + j + 1]);
+            if ((continuation & 0xC0) != 0x80) {
+                return false;
+            }
+            codePoint = (codePoint << 6) | (continuation & 0x3F);
+        }
+
+        if ((remaining == 1 && codePoint < 0x80) || (remaining == 2 && codePoint < 0x800)
+            || (remaining == 3 && codePoint < 0x10000)) {
+            return false;
+        }
+
+        if (codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+            return false;
+        }
+
+        out.push_back(codePoint);
+        i += remaining + 1;
+    }
+
+    return true;
+}
+
+bool splitBySpaces(const std::string& value, std::vector<std::string>& words) {
+    words.clear();
+    if (value.empty() || value.front() == ' ' || value.back() == ' ') {
+        return false;
+    }
+
+    std::size_t start = 0;
+    while (start < value.size()) {
+        std::size_t end = value.find(' ', start);
+        std::size_t length = (end == std::string::npos) ? value.size() - start : end - start;
+        if (length == 0) {
+            return false;
+        }
+        words.emplace_back(value.substr(start, length));
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+
+    return true;
 }
 
 } // namespace string_utils

--- a/string_utils.hpp
+++ b/string_utils.hpp
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <string>
+#include <vector>
+#include <cstdint>
 
 namespace string_utils {
 
@@ -16,6 +18,10 @@ void trimCarriageReturn(std::string& value);
 void stripUtf8Bom(std::string& value);
 
 bool splitLine(const std::string& line, char delimiter, std::string* fields, std::size_t expectedCount);
+
+bool decodeUtf8(const std::string& text, std::u32string& out);
+
+bool splitBySpaces(const std::string& value, std::vector<std::string>& words);
 
 } // namespace string_utils
 

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -311,8 +311,8 @@ TEST(DataIntegratorTest, IntegratorSavesToFile) {
         "DL001|Испытатель Альфа Сергеевич|Tesla\n"
         "DL002|Испытатель Бета Андреевич|Audi\n"
         "orders 2\n"
-        "DL001|Улица Опытная 7|100,00|2024-12-31\n"
-        "DL002|Улица Опытная 8|200,00|2025-01-01\n";
+        "DL001|Улица Опытная 7|100,00|31 Dec 2024\n"
+        "DL002|Улица Опытная 8|200,00|01 Jan 2025\n";
     EXPECT_EQ(buffer.str(), expected);
 
     RemoveIfExists(tempPath);
@@ -372,8 +372,8 @@ TEST(DataIntegratorTest, IntegratorSavesOrdersSeparately) {
 
     std::string expected =
         "orders 2\n"
-        "DL300|Проспект Центральный 10|150,00|2024-05-01\n"
-        "DL400|Проспект Северный 12|210,00|2024-05-02\n";
+        "DL300|Проспект Центральный 10|150,00|01 May 2024\n"
+        "DL400|Проспект Северный 12|210,00|02 May 2024\n";
     EXPECT_EQ(buffer.str(), expected);
 
     RemoveIfExists(tempPath);

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -287,8 +287,8 @@ TEST(DataIntegratorUseCasesTest, UseCase13_GenerateReportByCriteria) {
     auto results = integrator.generateReport(driver.licenseNumber,
                                              driver.carBrand,
                                              matchOrder.address,
-                                             "2025-02-01",
-                                             "2025-02-28");
+                                             "01 Feb 2025",
+                                             "28 Feb 2025");
     ASSERT_EQ(results.size(), 1u);
     EXPECT_EQ(results.front().address, matchOrder.address);
     EXPECT_EQ(results.front().date, matchOrder.date.displayString());
@@ -300,15 +300,15 @@ TEST(DataIntegratorUseCasesTest, UseCase13_GenerateReportByCriteria) {
     auto none = integrator.generateReport(driver.licenseNumber,
                                           "IncorrectBrand",
                                           matchOrder.address,
-                                          "2025-02-01",
-                                          "2025-02-28");
+                                          "01 Feb 2025",
+                                          "28 Feb 2025");
     EXPECT_TRUE(none.empty());
 
     auto outsideRange = integrator.generateReport(driver.licenseNumber,
                                                   driver.carBrand,
                                                   matchOrder.address,
-                                                  "2025-03-01",
-                                                  "2025-03-30");
+                                                  "01 Mar 2025",
+                                                  "30 Mar 2025");
     ASSERT_EQ(outsideRange.size(), 1u);
     EXPECT_EQ(outsideRange.front().date, laterOrder.date.displayString());
 }
@@ -464,8 +464,8 @@ TEST(DataIntegratorUseCasesTest, UseCase22_SaveTwoDriversAndOrders) {
         "DL001|Испытатель Альфа Сергеевич|Tesla\n"
         "DL002|Испытатель Бета Андреевич|Audi\n"
         "orders 2\n"
-        "DL001|Улица Опытная 7|100,00|2024-12-31\n"
-        "DL002|Улица Опытная 8|200,00|2025-01-01\n";
+        "DL001|Улица Опытная 7|100,00|31 Dec 2024\n"
+        "DL002|Улица Опытная 8|200,00|01 Jan 2025\n";
 
     EXPECT_EQ(buffer.str(), expected);
 

--- a/validation.cpp
+++ b/validation.cpp
@@ -4,7 +4,7 @@
 #include <regex>
 #include <string>
 #include <utility>
-#include <vector>
+#include "DoublyLinkedList.hpp" 
 
 #include "date.hpp"
 #include "string_utils.hpp"
@@ -54,8 +54,26 @@ bool ParseMonth(const std::string& token, Month& month) {
         }
     }
     return false;
-}
 
+
+}
+inline bool SplitBySpacesStrict(const std::string& s, DoublyLinkedList<std::string>& out) {
+    if (s.empty()) return false;
+    std::string cur;
+    for (char ch : s) {
+        if (ch == ' ') {
+            if (cur.empty()) return false; // ведущий или двойной пробел
+            out.push_back(cur);
+            cur.clear();
+        }
+        else {
+            cur.push_back(ch);
+        }
+    }
+    if (cur.empty()) return false; // замыкающий пробел
+    out.push_back(cur);
+    return true;
+}
 }  // namespace
 
 namespace validation {
@@ -70,27 +88,29 @@ bool isValidLicense(const std::string& value) {
 }
 
 bool isValidFio(const std::string& value) {
-    std::vector<std::string> parts;
-    if (!string_utils::splitBySpaces(value, parts) || parts.size() != 3) {
+    DoublyLinkedList<std::string> parts;
+    if (!SplitBySpacesStrict(value, parts) || parts.size() != 3) {
         return false;
     }
 
-    for (const std::string& part : parts) {
+    bool ok = true;
+    parts.for_each_while([&](const std::string& part, size_t) {
         std::u32string codePoints;
         if (!string_utils::decodeUtf8(part, codePoints) || codePoints.empty()) {
-            return false;
+            ok = false; return false;
         }
         if (!IsRussianUpper(codePoints.front())) {
-            return false;
+            ok = false; return false;
         }
         for (std::size_t i = 1; i < codePoints.size(); ++i) {
             if (!IsRussianLower(codePoints[i])) {
-                return false;
+                ok = false; return false;
             }
         }
-    }
+        return true;
+        });
 
-    return true;
+    return ok;
 }
 
 bool isValidCarBrand(const std::string& value) {
@@ -129,76 +149,61 @@ bool isValidCarBrand(const std::string& value) {
 }
 
 bool isValidAddress(const std::string& value) {
-    std::vector<std::string> tokens;
-    if (!string_utils::splitBySpaces(value, tokens) || tokens.empty()) {
+    DoublyLinkedList<std::string> tokens;
+    if (!SplitBySpacesStrict(value, tokens) || tokens.empty()) {
         return false;
     }
 
     bool first = true;
-    for (const std::string& token : tokens) {
+    bool ok = true;
+
+    tokens.for_each_while([&](const std::string& token, size_t) {
         std::string core = token;
         while (!core.empty() && (core.back() == '.' || core.back() == ',')) {
             core.pop_back();
         }
-        if (core.empty()) {
-            return false;
-        }
+        if (core.empty()) { ok = false; return false; }
 
         std::u32string codePoints;
         if (!string_utils::decodeUtf8(core, codePoints) || codePoints.empty()) {
-            return false;
+            ok = false; return false;
         }
 
         bool hasLetters = false;
         bool hasDigits = false;
         for (char32_t cp : codePoints) {
-            if (IsDigit(cp)) {
-                hasDigits = true;
-            }
-            else if (IsRussianLetter(cp)) {
-                hasLetters = true;
-            }
-            else {
-                return false;
-            }
+            if (IsDigit(cp))       hasDigits = true;
+            else if (IsRussianLetter(cp)) hasLetters = true;
+            else { ok = false; return false; }
         }
 
         if (hasLetters && hasDigits) {
             bool seenLetter = false;
             for (char32_t cp : codePoints) {
                 if (IsDigit(cp)) {
-                    if (seenLetter) {
-                        return false;
-                    }
+                    if (seenLetter) { ok = false; return false; }
                 }
                 else {
                     seenLetter = true;
-                    if (!IsRussianUpper(cp)) {
-                        return false;
-                    }
+                    if (!IsRussianUpper(cp)) { ok = false; return false; }
                 }
             }
         }
         else if (hasLetters) {
-            if (!IsRussianUpper(codePoints.front())) {
-                return false;
-            }
+            if (!IsRussianUpper(codePoints.front())) { ok = false; return false; }
             for (std::size_t i = 1; i < codePoints.size(); ++i) {
-                if (!IsRussianLower(codePoints[i])) {
-                    return false;
-                }
+                if (!IsRussianLower(codePoints[i])) { ok = false; return false; }
             }
         }
         else {
-            if (first) {
-                return false;
-            }
+            if (first) { ok = false; return false; }
         }
 
         first = false;
-    }
+        return true;
+        });
 
-    return true;
+    return ok;
 }
 
 bool isValidCost(const std::string& value) {

--- a/validation.cpp
+++ b/validation.cpp
@@ -1,0 +1,265 @@
+#include "validation.hpp"
+
+#include <algorithm>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "date.hpp"
+#include "string_utils.hpp"
+
+namespace {
+
+constexpr char32_t kCyrillicUpperA = U'\u0410';
+constexpr char32_t kCyrillicUpperYa = U'\u042F';
+constexpr char32_t kCyrillicLowerA = U'\u0430';
+constexpr char32_t kCyrillicLowerYa = U'\u044F';
+constexpr char32_t kCyrillicUpperYo = U'\u0401';
+constexpr char32_t kCyrillicLowerYo = U'\u0451';
+
+bool IsDigit(char32_t codePoint) {
+    return codePoint >= U'0' && codePoint <= U'9';
+}
+
+bool IsLatinUpper(char32_t codePoint) {
+    return codePoint >= U'A' && codePoint <= U'Z';
+}
+
+bool IsLatinLower(char32_t codePoint) {
+    return codePoint >= U'a' && codePoint <= U'z';
+}
+
+bool IsRussianUpper(char32_t codePoint) {
+    return (codePoint >= kCyrillicUpperA && codePoint <= kCyrillicUpperYa) || codePoint == kCyrillicUpperYo;
+}
+
+bool IsRussianLower(char32_t codePoint) {
+    return (codePoint >= kCyrillicLowerA && codePoint <= kCyrillicLowerYa) || codePoint == kCyrillicLowerYo;
+}
+
+bool IsRussianLetter(char32_t codePoint) {
+    return IsRussianUpper(codePoint) || IsRussianLower(codePoint);
+}
+
+bool ParseMonth(const std::string& token, Month& month) {
+    static const std::pair<const char*, Month> months[] = {
+        {"Jan", Month::Jan}, {"Feb", Month::Feb}, {"Mar", Month::Mar}, {"Apr", Month::Apr},
+        {"May", Month::May}, {"Jun", Month::Jun}, {"Jul", Month::Jul}, {"Aug", Month::Aug},
+        {"Sep", Month::Sep}, {"Oct", Month::Oct}, {"Nov", Month::Nov}, {"Dec", Month::Dec}};
+    for (const auto& [name, value] : months) {
+        if (token == name) {
+            month = value;
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+namespace validation {
+
+bool isValidLicense(const std::string& value) {
+    if (value.empty()) {
+        return false;
+    }
+    return std::all_of(value.begin(), value.end(), [](unsigned char ch) {
+        return (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9');
+    });
+}
+
+bool isValidFio(const std::string& value) {
+    std::vector<std::string> parts;
+    if (!string_utils::splitBySpaces(value, parts) || parts.size() != 3) {
+        return false;
+    }
+
+    for (const std::string& part : parts) {
+        std::u32string codePoints;
+        if (!string_utils::decodeUtf8(part, codePoints) || codePoints.empty()) {
+            return false;
+        }
+        if (!IsRussianUpper(codePoints.front())) {
+            return false;
+        }
+        for (std::size_t i = 1; i < codePoints.size(); ++i) {
+            if (!IsRussianLower(codePoints[i])) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool isValidCarBrand(const std::string& value) {
+    if (value.empty() || value.find(' ') != std::string::npos) {
+        return false;
+    }
+
+    std::u32string codePoints;
+    if (!string_utils::decodeUtf8(value, codePoints) || codePoints.empty()) {
+        return false;
+    }
+
+    bool useLatin = false;
+    if (IsLatinUpper(codePoints.front())) {
+        useLatin = true;
+    }
+    else if (!IsRussianUpper(codePoints.front())) {
+        return false;
+    }
+
+    for (std::size_t i = 1; i < codePoints.size(); ++i) {
+        char32_t cp = codePoints[i];
+        if (useLatin) {
+            if (!IsLatinLower(cp)) {
+                return false;
+            }
+        }
+        else {
+            if (!IsRussianLower(cp)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool isValidAddress(const std::string& value) {
+    std::vector<std::string> tokens;
+    if (!string_utils::splitBySpaces(value, tokens) || tokens.empty()) {
+        return false;
+    }
+
+    bool first = true;
+    for (const std::string& token : tokens) {
+        std::string core = token;
+        while (!core.empty() && (core.back() == '.' || core.back() == ',')) {
+            core.pop_back();
+        }
+        if (core.empty()) {
+            return false;
+        }
+
+        std::u32string codePoints;
+        if (!string_utils::decodeUtf8(core, codePoints) || codePoints.empty()) {
+            return false;
+        }
+
+        bool hasLetters = false;
+        bool hasDigits = false;
+        for (char32_t cp : codePoints) {
+            if (IsDigit(cp)) {
+                hasDigits = true;
+            }
+            else if (IsRussianLetter(cp)) {
+                hasLetters = true;
+            }
+            else {
+                return false;
+            }
+        }
+
+        if (hasLetters && hasDigits) {
+            bool seenLetter = false;
+            for (char32_t cp : codePoints) {
+                if (IsDigit(cp)) {
+                    if (seenLetter) {
+                        return false;
+                    }
+                }
+                else {
+                    seenLetter = true;
+                    if (!IsRussianUpper(cp)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        else if (hasLetters) {
+            if (!IsRussianUpper(codePoints.front())) {
+                return false;
+            }
+            for (std::size_t i = 1; i < codePoints.size(); ++i) {
+                if (!IsRussianLower(codePoints[i])) {
+                    return false;
+                }
+            }
+        }
+        else {
+            if (first) {
+                return false;
+            }
+        }
+
+        first = false;
+    }
+
+    return true;
+}
+
+bool isValidCost(const std::string& value) {
+    if (value.empty()) {
+        return false;
+    }
+
+    std::size_t commaPos = value.find(',');
+    if (commaPos == std::string::npos) {
+        return false;
+    }
+
+    std::string integerPart = value.substr(0, commaPos);
+    std::string fractionalPart = value.substr(commaPos + 1);
+
+    if (integerPart.empty() || fractionalPart.size() != 2) {
+        return false;
+    }
+
+    if (!std::all_of(integerPart.begin(), integerPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })
+        || !std::all_of(fractionalPart.begin(), fractionalPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })) {
+        return false;
+    }
+
+    bool integerAllZeros = std::all_of(integerPart.begin(), integerPart.end(), [](char ch) { return ch == '0'; });
+    if (integerAllZeros && fractionalPart == "00") {
+        return false;
+    }
+
+    return true;
+}
+
+bool parseDate(const std::string& value, Date& out) {
+    std::string trimmed = string_utils::trim(value);
+    if (trimmed.empty()) {
+        return false;
+    }
+
+    static const std::regex pattern(
+        R"(^(0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4})$)");
+    std::smatch match;
+    if (!std::regex_match(trimmed, match, pattern)) {
+        return false;
+    }
+
+    int day = std::stoi(match[1].str());
+    std::string monthToken = match[2].str();
+    int year = std::stoi(match[3].str());
+
+    Month monthValue;
+    if (!ParseMonth(monthToken, monthValue)) {
+        return false;
+    }
+
+    out = Date(day, monthValue, year);
+    return out.isValid();
+}
+
+bool isValidDate(const std::string& value) {
+    Date parsed{};
+    return parseDate(value, parsed);
+}
+
+}  // namespace validation

--- a/validation.hpp
+++ b/validation.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+struct Date;
+
+namespace validation {
+
+bool isValidLicense(const std::string& value);
+
+bool isValidFio(const std::string& value);
+
+bool isValidCarBrand(const std::string& value);
+
+bool isValidAddress(const std::string& value);
+
+bool isValidCost(const std::string& value);
+
+bool parseDate(const std::string& value, Date& out);
+
+bool isValidDate(const std::string& value);
+
+}  // namespace validation


### PR DESCRIPTION
## Summary
- centralize UTF-8 and field validation helpers in shared utilities and a new validation module that is reused by the GUI and data loader
- enforce full record validation for file imports and adopt the DD Mon YYYY date format for storage and display (with YYYYMMDD keys for trees)
- add a save-to-file option to the report window and refresh tests to cover the new date format

## Testing
- ctest --test-dir build --output-on-failure

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e10210588324961ee5e0905cc350)