### PR TITLE
Enforce Latin .txt filenames for file I/O

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -474,6 +474,9 @@ void DataIntegrator::clear() {
 }
 
 bool DataIntegrator::loadFromFile(const std::string& path, std::size_t initialDriverTableSize) {
+    if (!string_utils::isValidTxtFilePath(path)) {
+        return false;
+    }
     std::ifstream input(path, std::ios::binary);
     if (!input.is_open()) return false;
 
@@ -572,6 +575,9 @@ bool DataIntegrator::loadFromFile(const std::string& path, std::size_t initialDr
 }
 
 bool DataIntegrator::loadDriversFromFile(const std::string& path, std::size_t initialDriverTableSize) {
+    if (!string_utils::isValidTxtFilePath(path)) {
+        return false;
+    }
     std::ifstream input(path, std::ios::binary);
     if (!input.is_open()) return false;
 
@@ -746,6 +752,10 @@ bool DataIntegrator::loadOrdersFromFile(const std::string& path) {
         return false;
     }
 
+    if (!string_utils::isValidTxtFilePath(path)) {
+        return false;
+    }
+
     std::ifstream input(path, std::ios::binary);
     if (!input.is_open()) return false;
 
@@ -820,6 +830,9 @@ bool DataIntegrator::loadOrdersFromFile(const std::string& path) {
 }
 
 bool DataIntegrator::saveToFile(const std::string& path) const {
+    if (!string_utils::isValidTxtFilePath(path)) {
+        return false;
+    }
     std::ofstream output(path);
     if (!output.is_open()) return false;
 
@@ -837,6 +850,10 @@ bool DataIntegrator::saveDriversToFile(const std::string& path) const {
         return false;
     }
 
+    if (!string_utils::isValidTxtFilePath(path)) {
+        return false;
+    }
+
     std::ofstream output(path);
     if (!output.is_open()) {
         return false;
@@ -846,6 +863,10 @@ bool DataIntegrator::saveDriversToFile(const std::string& path) const {
 
 bool DataIntegrator::saveOrdersToFile(const std::string& path) const {
     if (!orderTreeReady_ && !orders_.empty()) {
+        return false;
+    }
+
+    if (!string_utils::isValidTxtFilePath(path)) {
         return false;
     }
 
@@ -934,6 +955,9 @@ std::string DataIntegrator::orderDateTreeAsText() const {
 
 bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std::string& treePath) const {
     if (!hashTablePath.empty()) {
+        if (!string_utils::isValidTxtFilePath(hashTablePath)) {
+            return false;
+        }
         std::ofstream hashOut(hashTablePath);
         if (!hashOut.is_open()) {
             return false;
@@ -951,6 +975,9 @@ bool DataIntegrator::saveStructures(const std::string& hashTablePath, const std:
     }
 
     if (!treePath.empty()) {
+        if (!string_utils::isValidTxtFilePath(treePath)) {
+            return false;
+        }
         std::ofstream treeOut(treePath);
         if (!treeOut.is_open()) {
             return false;

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -25,9 +25,9 @@
 #include <optional>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "data_integrator.hpp"
+#include "string_utils.hpp"
 #include "validation.hpp"
 
 namespace {
@@ -511,7 +511,14 @@ void IntegratorGUI::showTextWindow(const std::string& title, const std::string& 
                 return;
             }
 
-            std::ofstream output(filename, std::ios::binary);
+            std::string path(filename);
+            if (!string_utils::isValidTxtFilePath(path)) {
+                fl_message_title("Ошибка");
+                fl_alert("Файл должен иметь латинское имя и расширение .txt.");
+                return;
+            }
+
+            std::ofstream output(path, std::ios::binary);
             if (!output) {
                 fl_message_title("Ошибка");
                 fl_alert("Не удалось открыть файл для записи.");
@@ -781,19 +788,47 @@ std::optional<std::string> IntegratorGUI::promptFilePath(const char* dialogTitle
         chooser.options(Fl_Native_File_Chooser::SAVEAS_CONFIRM);
     }
 
+    auto validatePath = [&](const std::string& candidate) -> std::optional<std::string> {
+        if (candidate.empty()) {
+            if (allowEmpty) {
+                return std::string();
+            }
+            showError("Имя файла не может быть пустым.");
+            return std::nullopt;
+        }
+        if (!string_utils::isValidTxtFilePath(candidate)) {
+            showError("Имя файла должно быть латиницей и иметь расширение .txt.");
+            return std::nullopt;
+        }
+        return candidate;
+    };
+
     int result = chooser.show();
     if (result == 0) {
         const char* filename = chooser.filename();
         if (filename && *filename) {
-            return std::string(filename);
+            auto validated = validatePath(std::string(filename));
+            if (validated) {
+                return validated;
+            }
+            return std::nullopt;
         }
-        return allowEmpty ? std::optional<std::string>(std::string()) : std::nullopt;
+        auto validated = validatePath(std::string());
+        if (validated) {
+            return validated;
+        }
+        return std::nullopt;
     }
     if (result == 1) {
-        if (allowEmpty) {
-            return promptString(manualPrompt);
+        std::optional<std::string> manual = allowEmpty ? promptString(manualPrompt) : promptNonEmpty(manualPrompt);
+        if (!manual) {
+            return std::nullopt;
         }
-        return promptNonEmpty(manualPrompt);
+        auto validated = validatePath(*manual);
+        if (validated) {
+            return validated;
+        }
+        return std::nullopt;
     }
 
     std::ostringstream error;

--- a/string_utils.cpp
+++ b/string_utils.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cstddef>
-#include <vector>
 
 namespace string_utils {
 
@@ -133,27 +132,69 @@ bool decodeUtf8(const std::string& text, std::u32string& out) {
     return true;
 }
 
-bool splitBySpaces(const std::string& value, std::vector<std::string>& words) {
-    words.clear();
-    if (value.empty() || value.front() == ' ' || value.back() == ' ') {
+std::string extractFileName(const std::string& path) {
+    if (path.empty()) {
+        return {};
+    }
+
+    std::size_t index = path.size();
+    while (index > 0) {
+        char ch = path[index - 1];
+        if (ch == '/' || ch == '\\') {
+            break;
+        }
+        --index;
+    }
+
+    return path.substr(index);
+}
+
+bool hasTxtExtension(const std::string& path) {
+    std::string fileName = extractFileName(path);
+    if (fileName.size() < 4) {
         return false;
     }
 
-    std::size_t start = 0;
-    while (start < value.size()) {
-        std::size_t end = value.find(' ', start);
-        std::size_t length = (end == std::string::npos) ? value.size() - start : end - start;
-        if (length == 0) {
-            return false;
-        }
-        words.emplace_back(value.substr(start, length));
-        if (end == std::string::npos) {
-            break;
-        }
-        start = end + 1;
+    std::string extension = toLower(fileName.substr(fileName.size() - 4));
+    return extension == ".txt";
+}
+
+namespace {
+bool isLatinOrDigit(char ch) {
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+        return true;
+    }
+    if (ch >= '0' && ch <= '9') {
+        return true;
+    }
+    return ch == '_' || ch == '-';
+}
+} // namespace
+
+bool isLatinFileName(const std::string& path) {
+    std::string fileName = extractFileName(path);
+    if (!hasTxtExtension(fileName)) {
+        return false;
     }
 
+    if (fileName.size() <= 4) {
+        return false;
+    }
+
+    std::size_t limit = fileName.size() - 4;
+    for (std::size_t i = 0; i < limit; ++i) {
+        if (!isLatinOrDigit(fileName[i])) {
+            return false;
+        }
+    }
     return true;
+}
+
+bool isValidTxtFilePath(const std::string& path) {
+    if (!hasTxtExtension(path)) {
+        return false;
+    }
+    return isLatinFileName(path);
 }
 
 } // namespace string_utils

--- a/string_utils.hpp
+++ b/string_utils.hpp
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <string>
-#include <vector>
 #include <cstdint>
 
 namespace string_utils {
@@ -21,7 +20,13 @@ bool splitLine(const std::string& line, char delimiter, std::string* fields, std
 
 bool decodeUtf8(const std::string& text, std::u32string& out);
 
-bool splitBySpaces(const std::string& value, std::vector<std::string>& words);
+std::string extractFileName(const std::string& path);
+
+bool hasTxtExtension(const std::string& path);
+
+bool isLatinFileName(const std::string& path);
+
+bool isValidTxtFilePath(const std::string& path);
 
 } // namespace string_utils
 

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -457,10 +457,10 @@ TEST(DataIntegratorTest, IntegratorDumpsStructuresToText) {
     EXPECT_NE(treeDump.find("|--"), std::string::npos);
 
     auto basePath = TempFilePathForCurrentTest();
-    auto hashPath = basePath;
-    hashPath += ".hash";
-    auto treePath = basePath;
-    treePath += ".tree";
+    auto baseDir = basePath.parent_path();
+    std::string stem = basePath.stem().string();
+    auto hashPath = baseDir / (stem + "_hash.txt");
+    auto treePath = baseDir / (stem + "_tree.txt");
 
     RemoveIfExists(hashPath);
     RemoveIfExists(treePath);

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -26,7 +26,7 @@ std::filesystem::path TempFilePathForCurrentTest() {
     else {
         fileName += "temp";
     }
-    fileName += ".tmp";
+    fileName += ".txt";
     return tempDir / fileName;
 }
 
@@ -600,10 +600,10 @@ TEST(DataIntegratorUseCasesTest, UseCase29_SaveDiagnosticsSeparately) {
     auto treeDump = integrator.orderTreeAsText();
 
     auto base = TempFilePathForCurrentTest();
-    auto hashPath = base;
-    hashPath += ".hash";
-    auto treePath = base;
-    treePath += ".tree";
+    auto baseDir = base.parent_path();
+    std::string stem = base.stem().string();
+    auto hashPath = baseDir / (stem + "_hash.txt");
+    auto treePath = baseDir / (stem + "_tree.txt");
     RemoveIfExists(hashPath);
     RemoveIfExists(treePath);
 
@@ -635,10 +635,10 @@ TEST(DataIntegratorUseCasesTest, UseCase30_SaveDiagnosticsBothStructures) {
     auto treeDump = integrator.orderTreeAsText();
 
     auto base = TempFilePathForCurrentTest();
-    auto hashPath = base;
-    hashPath += ".hash";
-    auto treePath = base;
-    treePath += ".tree";
+    auto baseDir = base.parent_path();
+    std::string stem = base.stem().string();
+    auto hashPath = baseDir / (stem + "_hash.txt");
+    auto treePath = baseDir / (stem + "_tree.txt");
     RemoveIfExists(hashPath);
     RemoveIfExists(treePath);
 


### PR DESCRIPTION
## Summary
- add string utility helpers that enforce Latin-named .txt paths and remove the unused vector-based splitter
- apply the new validation across DataIntegrator save/load paths and GUI file dialogs
- adjust integration tests to create compliant temporary files for diagnostics

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915343ade8483249dc70c6a12783a8c)