### PR TITLE
Store order cost as double and format consistently

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1,6 +1,7 @@
 #include "data_integrator.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <sstream>
@@ -42,14 +43,16 @@ bool parseOrderLine(const std::string& line, OrderRecord& out) {
     }
 
     Date parsed{};
+    double parsedCost = 0.0;
     if (!validation::isValidLicense(parts[0]) || !validation::isValidAddress(parts[1])
-        || !validation::isValidCost(parts[2]) || !validation::parseDate(parts[3], parsed)) {
+        || !validation::isValidCost(parts[2]) || !validation::parseDate(parts[3], parsed)
+        || !string_utils::parseCost(parts[2], parsedCost)) {
         return false;
     }
 
     out.licenseNumber = parts[0];
     out.address = parts[1];
-    out.cost = parts[2];
+    out.cost = parsedCost;
     out.date = parsed;
     return true;
 }
@@ -72,7 +75,8 @@ bool writeOrderSection(std::ostream& output, const DoublyLinkedList<OrderRecord>
         return false;
     }
     orders.for_each([&](const OrderRecord& order, std::size_t) {
-        output << order.licenseNumber << '|' << order.address << '|' << order.cost << '|' << order.date.storageString()
+        output << order.licenseNumber << '|' << order.address << '|' << string_utils::formatCost(order.cost)
+               << '|' << order.date.storageString()
                << '\n';
     });
     output.flush();
@@ -166,7 +170,8 @@ void appendOrderNodeDetailed(const AVLNode*                     node,
             out << childPrefix << "• ";
             if (listIndex < orders.size()) {
                 const OrderRecord& order = orders.at(listIndex);
-                out << order.address << " | " << order.cost << " | " << order.date.displayString();
+                out << order.address << " | " << string_utils::formatCost(order.cost) << " | "
+                    << order.date.displayString();
             }
             else {
                 out << "(недопустимый индекс " << listIndex << ")";
@@ -229,7 +234,8 @@ void appendDateNodeDetailed(const AVLNode*                     node,
             out << childPrefix << "• ";
             if (listIndex < orders.size()) {
                 const OrderRecord& order = orders.at(listIndex);
-                out << order.licenseNumber << " | " << order.address << " | " << order.cost;
+                out << order.licenseNumber << " | " << order.address << " | "
+                    << string_utils::formatCost(order.cost);
             }
             else {
                 out << "(недопустимый индекс " << listIndex << ")";
@@ -1067,7 +1073,7 @@ bool DataIntegrator::validateDriverRecord(const DriverRecord& record) const {
 bool DataIntegrator::validateOrderRecord(const OrderRecord& record) const {
     if (record.licenseNumber.empty()) return false;
     if (record.address.empty()) return false;
-    if (record.cost.empty()) return false;
+    if (!(record.cost > 0.0) || !std::isfinite(record.cost)) return false;
     if (!record.date.isValid()) return false;
     return true;
 }
@@ -1180,7 +1186,7 @@ DoublyLinkedList<ReportEntry> DataIntegrator::generateReport(const std::string& 
                                      driver.fio,
                                      driver.carBrand,
                                      order.address,
-                                     order.cost,
+                                     string_utils::formatCost(order.cost),
                                      order.date.displayString()});
     });
 

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -160,7 +160,7 @@ protected:
                     switch (col) {
                         case 0: text = order.licenseNumber; break;
                         case 1: text = order.address; break;
-                        case 2: text = order.cost; break;
+                        case 2: text = string_utils::formatCost(order.cost); break;
                         case 3: text = order.date.displayString(); break;
                         default: break;
                     }
@@ -726,7 +726,8 @@ std::optional<OrderRecord> IntegratorGUI::promptOrder(const OrderRecord* initial
     std::optional<std::string> address = promptAddress("Адрес заказа:", initial ? initial->address : "");
     if (!address) return std::nullopt;
 
-    std::optional<std::string> cost = promptCost("Стоимость:", initial ? initial->cost : "");
+    std::optional<std::string> cost = promptCost(
+        "Стоимость:", initial ? string_utils::formatCost(initial->cost) : "");
     if (!cost) return std::nullopt;
 
     std::string datePromptDefault;
@@ -739,7 +740,13 @@ std::optional<OrderRecord> IntegratorGUI::promptOrder(const OrderRecord* initial
         return std::nullopt;
     }
 
-    OrderRecord record{*license, *address, *cost, *parsedDate};
+    double numericCost = 0.0;
+    if (!string_utils::parseCost(*cost, numericCost)) {
+        showError("Не удалось преобразовать стоимость.");
+        return std::nullopt;
+    }
+
+    OrderRecord record{*license, *address, numericCost, *parsedDate};
     return record;
 }
 
@@ -1114,7 +1121,8 @@ void IntegratorGUI::handleUpdateOrder() {
     list << "Заказы водителя " << *license << ":\n\n";
     for (std::size_t i = 0; i < orders.size(); ++i) {
         const OrderRecord& order = orders[i];
-        list << (i + 1) << ") " << order.address << " | " << order.cost << " | " << order.date.displayString() << "\n";
+        list << (i + 1) << ") " << order.address << " | "
+             << string_utils::formatCost(order.cost) << " | " << order.date.displayString() << "\n";
     }
     showInfo(list.str());
 
@@ -1152,7 +1160,8 @@ void IntegratorGUI::handleRemoveOrder() {
     list << "Заказы водителя " << *license << ":\n\n";
     for (std::size_t i = 0; i < orders.size(); ++i) {
         const OrderRecord& order = orders[i];
-        list << (i + 1) << ") " << order.address << " | " << order.cost << " | " << order.date.displayString() << "\n";
+        list << (i + 1) << ") " << order.address << " | "
+             << string_utils::formatCost(order.cost) << " | " << order.date.displayString() << "\n";
     }
     showInfo(list.str());
 

--- a/order_record.hpp
+++ b/order_record.hpp
@@ -4,15 +4,16 @@
 #include <string>
 
 #include "date.hpp"
+#include "string_utils.hpp"
 
 struct OrderRecord {
     std::string licenseNumber;
     std::string address;
-    std::string cost;
+    double      cost;
     Date        date;
 
     std::string toString() const {
-        return licenseNumber + "|" + address + "|" + cost + "|" + date.storageString();
+        return licenseNumber + "|" + address + "|" + string_utils::formatCost(cost) + "|" + date.storageString();
     }
 };
 

--- a/string_utils.cpp
+++ b/string_utils.cpp
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <cctype>
 #include <cstddef>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <stdexcept>
 
 namespace string_utils {
 
@@ -195,6 +199,55 @@ bool isValidTxtFilePath(const std::string& path) {
         return false;
     }
     return isLatinFileName(path);
+}
+
+bool parseCost(const std::string& text, double& out) {
+    if (text.empty()) {
+        return false;
+    }
+
+    std::size_t commaPos = text.find(',');
+    if (commaPos == std::string::npos) {
+        return false;
+    }
+
+    std::string integerPart = text.substr(0, commaPos);
+    std::string fractionalPart = text.substr(commaPos + 1);
+    if (integerPart.empty() || fractionalPart.size() != 2) {
+        return false;
+    }
+
+    auto isDigit = [](unsigned char ch) { return ch >= '0' && ch <= '9'; };
+    if (!std::all_of(integerPart.begin(), integerPart.end(), isDigit)
+        || !std::all_of(fractionalPart.begin(), fractionalPart.end(), isDigit)) {
+        return false;
+    }
+
+    bool integerAllZeros = std::all_of(integerPart.begin(), integerPart.end(), [](char ch) { return ch == '0'; });
+    if (integerAllZeros && fractionalPart == "00") {
+        return false;
+    }
+
+    std::string normalized = integerPart + '.' + fractionalPart;
+    try {
+        out = std::stod(normalized);
+    }
+    catch (const std::exception&) {
+        return false;
+    }
+    return true;
+}
+
+std::string formatCost(double value) {
+    std::ostringstream out;
+    out.setf(std::ios::fixed);
+    out << std::setprecision(2) << value;
+    std::string result = out.str();
+    std::size_t dotPos = result.find('.');
+    if (dotPos != std::string::npos) {
+        result[dotPos] = ',';
+    }
+    return result;
 }
 
 } // namespace string_utils

--- a/string_utils.hpp
+++ b/string_utils.hpp
@@ -28,5 +28,9 @@ bool isLatinFileName(const std::string& path);
 
 bool isValidTxtFilePath(const std::string& path);
 
+bool parseCost(const std::string& text, double& out);
+
+std::string formatCost(double value);
+
 } // namespace string_utils
 

--- a/tests/integrator_test.cpp
+++ b/tests/integrator_test.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "data_integrator.hpp"
+#include "string_utils.hpp"
 
 namespace {
 
@@ -45,7 +46,12 @@ OrderRecord MakeOrder(const std::string& license,
         ADD_FAILURE() << "Не удалось разобрать дату: " << dateText;
         parsed = Date();
     }
-    return OrderRecord{license, address, cost, parsed};
+    double parsedCost = 0.0;
+    if (!string_utils::parseCost(cost, parsedCost)) {
+        ADD_FAILURE() << "Не удалось преобразовать стоимость: " << cost;
+        parsedCost = 0.0;
+    }
+    return OrderRecord{license, address, parsedCost, parsed};
 }
 
 template <typename T>
@@ -212,7 +218,7 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
     auto firstOrders = integrator.ordersForDriver("VB100");
     ASSERT_EQ(firstOrders.size(), 1u);
     EXPECT_EQ(firstOrders[0].address, "Улица Сиреневая 1");
-    EXPECT_EQ(firstOrders[0].cost, "1000,00");
+    EXPECT_DOUBLE_EQ(firstOrders[0].cost, 1000.0);
     EXPECT_EQ(firstOrders[0].date.displayString(), "01 Dec 2024");
 
     auto lastDriver = integrator.findDriver("VB149");
@@ -223,7 +229,7 @@ TEST(DataIntegratorTest, IntegratorLoadsConfigBasic) {
     auto lastOrders = integrator.ordersForDriver("VB149");
     ASSERT_EQ(lastOrders.size(), 1u);
     EXPECT_EQ(lastOrders[0].address, "Улица Сиреневая 50");
-    EXPECT_EQ(lastOrders[0].cost, "1490,00");
+    EXPECT_DOUBLE_EQ(lastOrders[0].cost, 1490.0);
     EXPECT_EQ(lastOrders[0].date.displayString(), "19 Jan 2025");
 }
 
@@ -397,7 +403,7 @@ TEST(DataIntegratorTest, IntegratorSavesAndReloadsModifications) {
     OrderRecord original = existingOrders[0];
     OrderRecord updatedOrder = original;
     updatedOrder.address = "Проспект Мира 10";
-    updatedOrder.cost = "2700,00";
+    updatedOrder.cost = 2700.0;
     EXPECT_TRUE(integrator.updateOrder(original, updatedOrder));
 
     std::size_t initialOrderCount = integrator.orderCount();

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string>
 #include "data_integrator.hpp"
+#include "string_utils.hpp"
 
 namespace {
 
@@ -44,7 +45,12 @@ OrderRecord MakeOrder(const std::string& license,
         ADD_FAILURE() << "Не удалось разобрать дату: " << dateText;
         parsed = Date();
     }
-    return OrderRecord{license, address, cost, parsed};
+    double parsedCost = 0.0;
+    if (!string_utils::parseCost(cost, parsedCost)) {
+        ADD_FAILURE() << "Не удалось преобразовать стоимость: " << cost;
+        parsedCost = 0.0;
+    }
+    return OrderRecord{license, address, parsedCost, parsed};
 }
 
 template <typename T>
@@ -334,7 +340,7 @@ TEST(DataIntegratorUseCasesTest, UseCase13_FilterByLicenseNumber) {
     auto orders = integrator.ordersForDriver("VB100");
     ASSERT_EQ(orders.size(), 1u);
     EXPECT_EQ(orders.front().address, "Улица Сиреневая 1");
-    EXPECT_EQ(orders.front().cost, "1000,00");
+    EXPECT_DOUBLE_EQ(orders.front().cost, 1000.0);
     EXPECT_EQ(orders.front().date.displayString(), "01 Dec 2024");
 }
 
@@ -373,7 +379,7 @@ TEST(DataIntegratorUseCasesTest, UseCase17_FilterOrdersByDriverLicense) {
     auto orders = integrator.ordersForDriver("VB149");
     ASSERT_EQ(orders.size(), 1u);
     EXPECT_EQ(orders.front().address, "Улица Сиреневая 50");
-    EXPECT_EQ(orders.front().cost, "1490,00");
+    EXPECT_DOUBLE_EQ(orders.front().cost, 1490.0);
     EXPECT_EQ(orders.front().date.displayString(), "19 Jan 2025");
 }
 

--- a/validation.cpp
+++ b/validation.cpp
@@ -62,7 +62,7 @@ inline bool SplitBySpacesStrict(const std::string& s, DoublyLinkedList<std::stri
     std::string cur;
     for (char ch : s) {
         if (ch == ' ') {
-            if (cur.empty()) return false; // âåäóùèé èëè äâîéíîé ïðîáåë
+            if (cur.empty()) return false; // Ã¢Ã¥Ã¤Ã³Ã¹Ã¨Ã© Ã¨Ã«Ã¨ Ã¤Ã¢Ã®Ã©Ã­Ã®Ã© Ã¯Ã°Ã®Ã¡Ã¥Ã«
             out.push_back(cur);
             cur.clear();
         }
@@ -70,7 +70,7 @@ inline bool SplitBySpacesStrict(const std::string& s, DoublyLinkedList<std::stri
             cur.push_back(ch);
         }
     }
-    if (cur.empty()) return false; // çàìûêàþùèé ïðîáåë
+    if (cur.empty()) return false; // Ã§Ã Ã¬Ã»ÃªÃ Ã¾Ã¹Ã¨Ã© Ã¯Ã°Ã®Ã¡Ã¥Ã«
     out.push_back(cur);
     return true;
 }
@@ -207,33 +207,8 @@ bool isValidAddress(const std::string& value) {
 }
 
 bool isValidCost(const std::string& value) {
-    if (value.empty()) {
-        return false;
-    }
-
-    std::size_t commaPos = value.find(',');
-    if (commaPos == std::string::npos) {
-        return false;
-    }
-
-    std::string integerPart = value.substr(0, commaPos);
-    std::string fractionalPart = value.substr(commaPos + 1);
-
-    if (integerPart.empty() || fractionalPart.size() != 2) {
-        return false;
-    }
-
-    if (!std::all_of(integerPart.begin(), integerPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })
-        || !std::all_of(fractionalPart.begin(), fractionalPart.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; })) {
-        return false;
-    }
-
-    bool integerAllZeros = std::all_of(integerPart.begin(), integerPart.end(), [](char ch) { return ch == '0'; });
-    if (integerAllZeros && fractionalPart == "00") {
-        return false;
-    }
-
-    return true;
+    double parsed = 0.0;
+    return string_utils::parseCost(value, parsed);
 }
 
 bool parseDate(const std::string& value, Date& out) {


### PR DESCRIPTION
## Summary
- add reusable helpers to parse and format localized monetary values and switch order records to store cost as a double
- update the data integrator, GUI, and serialization/reporting logic to rely on numeric costs while displaying them in the expected "рубли,копейки" format
- refresh validation and the unit tests so that every code path now works with numeric order costs

## Testing
- `cmake --build build --target cursedarch_tests`
- `ctest --test-dir build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197318f5c083249094b5ed411105a8)