### PR TITLE
Remove license number filter from report generation

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1112,8 +1112,7 @@ void DataIntegrator::collectOrdersInDateRange(const AVLNode* node,
     collectOrdersInDateRange(node->right, fromKey, toKey, hasFrom, hasTo, indices);
 }
 
-DoublyLinkedList<ReportEntry> DataIntegrator::generateReport(const std::string& licenseNumber,
-                                                             const std::string& carBrand,
+DoublyLinkedList<ReportEntry> DataIntegrator::generateReport(const std::string& carBrand,
                                                              const std::string& address,
                                                              const std::string& dateFrom,
                                                              const std::string& dateTo) const {
@@ -1139,31 +1138,13 @@ DoublyLinkedList<ReportEntry> DataIntegrator::generateReport(const std::string& 
         });
     }
 
-    std::optional<DriverRecord> specificDriver;
-    if (!licenseNumber.empty()) {
-        specificDriver = findDriver(licenseNumber);
-        if (!specificDriver.has_value()) {
-            return result;
-        }
-    }
-
     candidateIndices.for_each([&](std::size_t index, std::size_t) {
         if (index >= orders_.size()) {
             return;
         }
         const OrderRecord& order = orders_.at(index);
 
-        if (!licenseNumber.empty() && order.licenseNumber != licenseNumber) {
-            return;
-        }
-
-        std::optional<DriverRecord> driverOpt;
-        if (specificDriver.has_value() && order.licenseNumber == specificDriver->licenseNumber) {
-            driverOpt = specificDriver;
-        }
-        else {
-            driverOpt = findDriver(order.licenseNumber);
-        }
+        auto driverOpt = findDriver(order.licenseNumber);
         if (!driverOpt.has_value()) {
             return;
         }

--- a/data_integrator.hpp
+++ b/data_integrator.hpp
@@ -63,8 +63,7 @@ public:
     std::string orderDateTreeAsText() const;
     bool saveStructures(const std::string& hashTablePath, const std::string& treePath) const;
 
-    DoublyLinkedList<ReportEntry> generateReport(const std::string& licenseNumber,
-                                                 const std::string& carBrand,
+    DoublyLinkedList<ReportEntry> generateReport(const std::string& carBrand,
                                                  const std::string& address,
                                                  const std::string& dateFrom,
                                                  const std::string& dateTo) const;

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -1252,8 +1252,6 @@ void IntegratorGUI::handleGenerateReport() {
         return;
     }
 
-    auto license = promptLicense("Номер лицензии для отчёта (можно оставить пустым):", "", true);
-    if (!license) return;
     auto carBrand = promptCarBrand("Марка автомобиля (можно оставить пустым):", "", true);
     if (!carBrand) return;
     auto address = promptAddress("Адрес заказа (можно оставить пустым):", "", true);
@@ -1277,7 +1275,7 @@ void IntegratorGUI::handleGenerateReport() {
                                   true);
     if (!toDate) return;
 
-    DoublyLinkedList<ReportEntry> entries = integrator_.generateReport(*license, *carBrand, *address, *fromDate, *toDate);
+    DoublyLinkedList<ReportEntry> entries = integrator_.generateReport(*carBrand, *address, *fromDate, *toDate);
     std::string text = integrator_.formatReport(entries);
     showTextWindow("Отчёт по водителю", text, true);
 }

--- a/tests/integrator_use_cases_test.cpp
+++ b/tests/integrator_use_cases_test.cpp
@@ -290,8 +290,7 @@ TEST(DataIntegratorUseCasesTest, UseCase13_GenerateReportByCriteria) {
     ASSERT_TRUE(integrator.addOrder(laterOrder));
     ASSERT_TRUE(integrator.addOrder(otherAddress));
 
-    auto results = integrator.generateReport(driver.licenseNumber,
-                                             driver.carBrand,
+    auto results = integrator.generateReport(driver.carBrand,
                                              matchOrder.address,
                                              "01 Feb 2025",
                                              "28 Feb 2025");
@@ -303,15 +302,13 @@ TEST(DataIntegratorUseCasesTest, UseCase13_GenerateReportByCriteria) {
     EXPECT_NE(formatted.find(driver.fio), std::string::npos);
     EXPECT_NE(formatted.find(matchOrder.date.displayString()), std::string::npos);
 
-    auto none = integrator.generateReport(driver.licenseNumber,
-                                          "IncorrectBrand",
+    auto none = integrator.generateReport("IncorrectBrand",
                                           matchOrder.address,
                                           "01 Feb 2025",
                                           "28 Feb 2025");
     EXPECT_TRUE(none.empty());
 
-    auto outsideRange = integrator.generateReport(driver.licenseNumber,
-                                                  driver.carBrand,
+    auto outsideRange = integrator.generateReport(driver.carBrand,
                                                   matchOrder.address,
                                                   "01 Mar 2025",
                                                   "30 Mar 2025");


### PR DESCRIPTION
## Summary
- remove the license number prompt from the report dialog and adjust the generator API accordingly
- simplify report generation so it only filters by car brand, address, and date range
- update the use-case tests to match the new report API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: "No test configuration file found!")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b47f0568832484ede46478853f77)