### PR TITLE
Add date range validation to report filters

### DIFF
--- a/data_integrator.cpp
+++ b/data_integrator.cpp
@@ -1128,6 +1128,10 @@ DoublyLinkedList<ReportEntry> DataIntegrator::generateReport(const std::string& 
     std::string fromKey = hasFrom ? fromDate.key() : std::string();
     std::string toKey = hasTo ? toDate.key() : std::string();
 
+    if (hasFrom && hasTo && fromKey > toKey) {
+        return result;
+    }
+
     DoublyLinkedList<std::size_t> candidateIndices;
     if ((hasFrom || hasTo) && orderDateTree_.root) {
         collectOrdersInDateRange(fromKey, toKey, hasFrom, hasTo, candidateIndices);

--- a/integrator_gui.cpp
+++ b/integrator_gui.cpp
@@ -1275,6 +1275,15 @@ void IntegratorGUI::handleGenerateReport() {
                                   true);
     if (!toDate) return;
 
+    Date parsedFrom{};
+    Date parsedTo{};
+    bool hasFromValue = !fromDate->empty() && Date::parse(*fromDate, parsedFrom);
+    bool hasToValue = !toDate->empty() && Date::parse(*toDate, parsedTo);
+    if (hasFromValue && hasToValue && parsedFrom.key() > parsedTo.key()) {
+        showError("Начальная дата не может быть позже конечной.");
+        return;
+    }
+
     DoublyLinkedList<ReportEntry> entries = integrator_.generateReport(*carBrand, *address, *fromDate, *toDate);
     std::string text = integrator_.formatReport(entries);
     showTextWindow("Отчёт по водителю", text, true);


### PR DESCRIPTION
## Summary
- validate date range inputs in the report dialog so the user is warned when the start date is after the end date
- defensively guard the report generator against inverted ranges to avoid accidental matches

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919bc172cf083249f23fcb47b6d3323)